### PR TITLE
[Feat] 공통 API 응답을 위한 ResponseInterceptor 추가

### DIFF
--- a/BE/src/common/dto/common-response.dto.ts
+++ b/BE/src/common/dto/common-response.dto.ts
@@ -1,0 +1,6 @@
+export class CommonResponseDto<T = any> {
+  success: boolean;
+  message: string;
+  error: null;
+  data: T | null;
+}

--- a/BE/src/common/interceptor/response.interceptor.ts
+++ b/BE/src/common/interceptor/response.interceptor.ts
@@ -1,0 +1,23 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nestjs/common";
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import { CommonResponseDto } from "../dto/common-response.dto";
+
+@Injectable()
+export class ResponseInterceptor<T>
+  implements NestInterceptor<T, CommonResponseDto<T>> {
+
+  intercept(
+    _: ExecutionContext,
+    next: CallHandler<T>,
+  ): Observable<CommonResponseDto<T>> {
+    return next.handle().pipe(
+      map((data) => ({
+        success: true,
+        message: '성공적으로 응답되었습니다.',
+        error: null,
+        data,
+      })),
+    );
+  }
+}

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ResponseInterceptor } from './common/interceptor/response.interceptor';
 
 // BigInt 전역 설정 (JSON.stringify 시 문자열로 변환)
 (BigInt.prototype as any).toJSON = function () {
@@ -8,6 +9,10 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // 응답 인터셉터 적용
+  app.useGlobalInterceptors(new ResponseInterceptor());
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
close #115 

## ⏳ 리뷰 예상 시간

- 1분

## 📝 기능 설명

- 모든 API 응답이 `CommonResponseDto` 형식을 따르도록 했어요.
```ts
export class CommonResponseDto<T = any> {
  success: boolean;
  message: string;
  error: null;
  data: T | null;
}
```

- 전역 응답 인터셉터를 적용해서 컨트롤러에서 별도의 응답 래핑 로직 없이도 동작하도록 했어요.
```ts
import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nestjs/common";
import { Observable } from "rxjs";
import { map } from "rxjs/operators";
import { CommonResponseDto } from "../dto/common-response.dto";

@Injectable()
export class ResponseInterceptor<T>
  implements NestInterceptor<T, CommonResponseDto<T>> {

  intercept(
    _: ExecutionContext,
    next: CallHandler<T>,
  ): Observable<CommonResponseDto<T>> {
    return next.handle().pipe(
      map((data) => ({
        success: true,
        message: '성공적으로 응답되었습니다.',
        error: null,
        data,
      })),
    );
  }
}
```

- 에러 응답 포맷은 따로 정의하지 않았는데, 이 부분은 따로 논의가 필요해보여요!

## 🛠 작업 사항

- `ResponseInterceptor` 클래스 추가
- `CommonResponseDto` 클래스 추가

## ✅ 작업 체크리스트

- [x] 모든 API 응답이 CommonResponseDto 형식을 따른다
- [x] 컨트롤러에서 별도의 응답 래핑 로직이 필요 없다