### PR TITLE
[Feat] 리뷰어 자동 할당 워크플로우 추가

### DIFF
--- a/.github/autoassign.yml
+++ b/.github/autoassign.yml
@@ -1,0 +1,49 @@
+name: Auto Assign Reviewers and Assignee
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Auto assign reviewers and assignee
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prAuthor = context.actor.toLowerCase();
+            const pr = context.payload.pull_request;
+
+            const members = [
+              'leehb-1007',
+              'limsr12',
+              'jangdongho',
+              'devjunz',
+              'whateveriiwant'
+            ];
+
+            // 전원 리뷰(작성자 제외)
+            const reviewers = members.filter(m => m !== prAuthor);
+
+            console.log(`PR Author: ${prAuthor}`);
+            console.log(`Assigned reviewers: ${reviewers.join(', ')}`);
+
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              reviewers
+            });
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              assignees: [prAuthor]
+            });


### PR DESCRIPTION
close #123

## ⏳ 리뷰 예상 시간

- 1분

## 📝 기능 설명
- 이제 수동으로 리뷰어 할당 안해도되영

## ⭐️ 리뷰 포인트

- 한 번 쓱 훑어보세영

## 🛠 작업 사항

<!-- 구현한 작업 내용을 설명해주세요 -->

## ✅ 작업 체크리스트



## 📎 개발 일지 및 참고 자료


