### PR TITLE
[Fix] 리뷰어 자동 할당 스크립트 수정

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -17,8 +17,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prAuthor = pr.user.login;
             const pr = context.payload.pull_request;
+            const prAuthor = pr.user.login;
 
             const reviewersMap = {
               'leeHB-1007': ['LimSR12', 'JangDongHo', 'whateveriiwant', 'DevJunz'],


### PR DESCRIPTION
## ⏳ 리뷰 예상 시간

- 10초

## 📝 기능 설명

- 리뷰어 자동 할당 스크립트를 수정했습니다.
- `reviewersMap` 에 깃허브 로그인 ID 를 사용하도록 일부 수정했습니다.
- 배열 안에 콤마가 빠져있어서 SyntaxError 가 났던 것 같습니다.
- `pull_request: types: [opened]` 트리거로 실행되는 스크립트라 여기서 재실행되지는 않는데, 아마 머지하면 정상 작동할 것 같아요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * 자동 PR 검토자 할당 시스템이 업데이트되었습니다. 검토자 매핑 및 기본 검토자 목록이 수정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->