### PR TITLE
[Fix] 프로젝트 전체조회 응답 정렬 순서 수정

### DIFF
--- a/BE/src/project/dto/project-list-item.dto.ts
+++ b/BE/src/project/dto/project-list-item.dto.ts
@@ -83,4 +83,11 @@ export class ProjectListItemDto {
   })
   @Expose()
   field: ProjectField | null;
+
+  @ApiProperty({
+    description: '팀 번호',
+    example: '1',
+  })
+  @Expose()
+  teamNumber: number;
 }

--- a/BE/src/project/project.repository.ts
+++ b/BE/src/project/project.repository.ts
@@ -38,7 +38,7 @@ export class ProjectRepository {
         where: {
           AND: [{ state: 'PUBLISHED' }, ...(where ? [where] : [])],
         },
-        orderBy: { teamNumber: 'desc' },
+        orderBy: { teamNumber: 'asc' },
         include: {
           techStacks: {
             select: {


### PR DESCRIPTION
## ⏳ 리뷰 예상 시간

- 1분

## 📝 기능 설명

- 프로젝트 전체 조회 API 에서 projects id(pk) 정렬되던 로직을 teamNumber 기준 정렬되도록 수정했습니다.

## 🛠 작업 사항

- 응답 DTO 에 teamNumber 필드 추가
- 조회 쿼리에서 order by id -> teamNumber 로 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로젝트 목록에 팀 번호 정보가 추가되었습니다.

* **개선사항**
  * 프로젝트 목록 정렬 순서가 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->