### PR TITLE
[Feat] 피드 파서에 이미지 URL 유효성 검사 추가

### DIFF
--- a/Crawler/src/feed-parser.ts
+++ b/Crawler/src/feed-parser.ts
@@ -186,7 +186,7 @@ export class FeedParser {
     }
 
     // 이미지 확장자 검증 (선택사항)
-    const imageExtensions = /\.(jpg|jpeg|png|gif|webp|svg)(\?|$)/i;
+    const imageExtensions = /\.(jpg|jpeg|png|gif|webp)(\?|$)/i;
     // 확장자가 있으면 확인, 없으면 일단 허용 (CDN URL 등)
     if (url.match(/\.[a-z]+(\?|$)/i) && !imageExtensions.test(url)) {
       return false;


### PR DESCRIPTION
close #201 

## ⏳ 리뷰 예상 시간

- 코드 리뷰: 2분
- 의견 교환: 5분

## 📝 기능 설명

- 피드 파서에 이미지 URL 유효성 검사 함수를 추가했어요.
- 유효성 검사 함수는 이미지 URL을 입력으로 받고 boolean을 출력해요. 검사 항목은 다음과 같아요.
  - HTTPS인가?
  - Placeholder 이미지가 아닌가?
  - 이미지 확장자가 포함돼있는가?

## ⭐️ 리뷰 포인트

- 제가 고민했던 포인트들은 다음과 같아요. 이 부분에 대한 여러분들의 의견이 필요해요!

---

1. **유효한 이미지인지 확인하기 위해 HTTP Request를 보내서 확인한다?**
  - 유효한 이미지 URL인지 확인하기 위해 HTTP 통신을 하는게 맞을지에 대한 의문이 들었어요. (200 응답 시 성공, 그 외 응답은 실패로 간주)
  - 이유는 RSS 아이템마다 이미지 검증을 위해 HTTP 요청을 하게 되면 크롤링 속도가 느려질 것 같았어요.
  - 그리고 수집 당시에는 유효한 이미지이지만, 이후에는 언제든지 삭제가 될 가능성이 있기 때문에 완벽한 해결책은 아니라고 생각했어요.
  - 따라서 저는 HTTP 요청 없이 URL만을 이용해 최소한의 검증만 하는 식으로 하고, 프론트에서 불러올 수 없는 이미지를 처리해주는 게 좋을 것 같다고 생각하는데 다른 분들의 의견이 궁금해요!

---

2. **검증된 hostname만 수집하는 것이 옳을까?**
  - 오늘 June 덕분에 next.js의 이미지 서버에 검증된 hostname만 보여줄 수 있도록 하는 기능이 있다는걸 알게 됐어요. (예: `velog.velcdn.com` 등)
  - 여기서 고민인 점은 수집 서버에서 검증된 hostname이 아니라면 아예 수집을 배제하는 것이 옳은가였어요.
  - 저는 외부 서비스의 이미지 정책은 언제든지 변경될 수 있다고 생각해서 가능하면 미검증된 hostname을 가진 이미지 url도 수집이 되면 좋겠다는 입장이에요.
  - 예를 들어, velog가 `velog.velcdn.com` 으로 이미지를 호스팅하다가 `veluga.veluga.com` 으로 변경된다면, 저희는 사용자가 올린 콘텐츠의 이미지를 수집해오지 못해요.
  - 그래서 next 이미지 서버의 화이트리스트 정책은 유지하되, 크롤링 단계에서는 미검증 hostname도 수집이 되는게 좋을 것 같은데 다른 분들은 어떤 의견이 있으신지 궁금해요!

## 📎 개발 일지 및 참고 자료

- [개발 일지](https://pole-position.notion.site/URL-2f0d4705e03f80e1a7f7fed49d0dca6e?source=copy_link)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 피드 이미지 URL 검증이 강화되었습니다. HTTPS 프로토콜 필수, 플레이스홀더 및 무효 이미지 패턴 제외, 이미지 확장자 검증이 추가되었습니다. 새로운 검증 기준을 충족하지 않는 이미지는 표시되지 않을 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->