### PR TITLE
[Feat] 프로젝트 조회수 증가 로직 추가

### DIFF
--- a/BE/src/project/project.repository.ts
+++ b/BE/src/project/project.repository.ts
@@ -8,6 +8,21 @@ import { UpdateProjectDto } from './dto/update-project.dto';
 export class ProjectRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  async incrementViewCountAndFind(id: bigint) {
+    return this.prisma.project.update({
+      where: { id },
+      data: { viewCount: { increment: 1 } },
+      include: {
+        participants: {
+          select: { githubId: true, avatarUrl: true },
+        },
+        techStacks: {
+          select: { techStack: { select: { name: true } } },
+        },
+      },
+    });
+  }
+
   async findById(id: bigint) {
     return this.prisma.project.findUnique({
       where: { id },


### PR DESCRIPTION
close #266

## ⏳ 리뷰 예상 시간

- 5분

## 📝 기능 설명

- 프로젝트 상세 조회 시 **조회수(viewCount)** 를 증가시키는 로직을 추가했습니다.
- 동일 사용자의 반복 요청으로 조회수가 과도하게 증가하는 것을 방지하기 위해  **Redis 기반의 중복 조회 제어(30분 단위)** 를 적용했습니다.

## ⭐️ 리뷰 포인트

- 조회수는 “의미 있는 조회” 기준으로 증가해야 하므로, 같은 사용자가 짧은 시간 내 여러 번 조회하더라도 **조회수는 1회만 증가**하도록 설계했습니다.
- 이미 Redis를 도입한 상태이기 때문에, DB 부하를 최소화하면서도 원자적으로 중복 조회를 제어할 수 있는 `SET NX EX` 패턴을 사용했습니다.
  - https://redisgate.kr/redis/command/set.php

## 🔄 전체 동작 흐름

### 1️⃣ Controller
- `GET /api/projects/{id}` 요청 시
  - 쿠키에 저장된 `bid` 값을 조회하여 `viewerKey`로 사용합니다.
  - 쿠키가 없는 경우, UUID를 새로 생성하여 `bid` 쿠키로 삽입합니다.
- 이렇게 생성/조회한 `viewerKey`를 서비스 레이어로 전달합니다.

### 2️⃣ Service
- Redis key를 다음과 같은 규칙으로 사용합니다. -> `view:project:{projectId}:{viewerKey}`
- Redis에 `SET key value EX 1800 NX` 명령을 실행합니다.
- key가 **존재하지 않는 경우** -> 최초 조회로 판단
  - DB 조회수(`viewCount`)를 1 증가
  - `incrementViewCountAndFind()` 호출
- key가 **이미 존재하는 경우** -> 중복 조회로 판단
  - 조회수는 증가시키지 않음
  - `findById()` 호출

### 3️⃣ Redis TTL
- Redis key는 30분 TTL을 가집니다.
- 따라서 동일 사용자는 **30분에 최대 1회만 조회수 증가**가 가능합니다.

## 🛠 작업 사항
- 프로젝트 상세 조회 API에 조회수 로직 추가
- Redis를 이용한 조회수 중복 방지 처리
- Controller에서 `viewerKey` 생성 및 쿠키 관리
- Repository에 조회수 증가 전용 메서드(`incrementViewCountAndFind`) 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로젝트별 조회수 추적 기능이 추가되었습니다.
  * 각 사용자를 고유하게 식별하여 중복 조회를 방지합니다.
  * 30분 내에 처음 조회한 경우만 조회수에 반영됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->