### PR TITLE
[Hotfix] 프로젝트 수정 시 팀원들의 avataUrl이 초기화 되는 문제 해결

### DIFF
--- a/BE/src/project/project.repository.ts
+++ b/BE/src/project/project.repository.ts
@@ -6,7 +6,7 @@ import { UpdateProjectDto } from './dto/update-project.dto';
 
 @Injectable()
 export class ProjectRepository {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService) { }
 
   async incrementViewCountAndFind(id: bigint) {
     return this.prisma.project.update({
@@ -177,7 +177,7 @@ export class ProjectRepository {
             data: uniqueGithubIds.map((githubId) => ({
               projectId: id,
               githubId,
-              avatarUrl: null,
+              avatarUrl: `https://avatars.githubusercontent.com/${githubId}?v=4`, // TODO: 깃허브 아바타 이미지 base url 상수화
             })),
           });
         }


### PR DESCRIPTION
## ⏳ 리뷰 예상 시간

- 1분

## 📝 기능 설명

- 프로젝트 수정 시 팀원들의 avataUrl이 초기화 되는 문제를 해결했어요.
- 깃허브 아바타 이미지 base url은 리팩토링 기간에 상수화 해야겠네요.

[기존]
```ts
await tx.projectParticipant.createMany({
  data: uniqueGithubIds.map((githubId) => ({
    projectId: id,
    githubId,
    avatarUrl: null,
  })),
});
```

[개선]
```ts
await tx.projectParticipant.createMany({
  data: uniqueGithubIds.map((githubId) => ({
    projectId: id,
    githubId,
    avatarUrl: `https://avatars.githubusercontent.com/${githubId}?v=4`,
  })),
});
```

## ⭐️ 리뷰 포인트

<!-- 리뷰 포인트를 작성해주세요 -->

## 🛠 작업 사항

<!-- 구현한 작업 내용을 설명해주세요 -->

## ✅ 작업 체크리스트

- [ ] 작업 1
- [ ] 작업 2

## 📎 개발 일지 및 참고 자료

<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 프로젝트 참여자의 아바타가 GitHub 프로필 이미지로 표시되도록 업데이트되었습니다. 이제 참여자 생성 및 업데이트 시 아바타 이미지가 정상적으로 로드됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->