### PR TITLE
[Hotfix] 프로젝트 생성 DTO URL 필드에 transform 추가

### DIFF
--- a/BE/src/answer/answer.service.ts
+++ b/BE/src/answer/answer.service.ts
@@ -11,7 +11,7 @@ export class AnswerService {
   constructor(
     private readonly answerRepo: AnswerRepository,
     private readonly authRepository: AuthRepository,
-  ) { }
+  ) {}
 
   async findOne(id: string) {
     const answer = await this.answerRepo.findOnePublished(id); // repo로 빼는 게 깔끔
@@ -94,7 +94,7 @@ export class AnswerService {
     const ownerId = await this.answerRepo.findOwnerIdByAnswerId(id);
     if (!ownerId) throw new NotFoundException('답변의 주인이 없소');
 
-    // ADMIN 권한 확인  
+    // ADMIN 권한 확인
     const member = await this.authRepository.findById(memberId);
     const canDelete = ownerId === memberId || member?.role === Role.ADMIN;
 

--- a/BE/src/common/guard/internal-request.guard.ts
+++ b/BE/src/common/guard/internal-request.guard.ts
@@ -5,10 +5,7 @@ const INTERNAL_HEADER_NAME = 'x-proxied-by';
 const INTERNAL_HEADER_VALUE = 'next';
 
 // 외부 접근을 허용해야 하는 경로들 (OAuth 콜백 등)
-const EXTERNAL_ACCESS_PATHS = [
-  '/api/auth/github/callback',
-  '/api/auth/login',
-];
+const EXTERNAL_ACCESS_PATHS = ['/api/auth/github/callback', '/api/auth/login'];
 
 const isExternalAccessPath = (path: string) => {
   return EXTERNAL_ACCESS_PATHS.some((allowedPath) => path.startsWith(allowedPath));

--- a/BE/src/project/dto/create-project.dto.ts
+++ b/BE/src/project/dto/create-project.dto.ts
@@ -43,7 +43,7 @@ export class CreateProjectDto {
     example: 'temp/projects/thumbnail/cc67be56-9026-4600-8444-b9c1fe399cf0.png',
   })
   @IsOptional()
-  @Transform(({ value }) => (value === '' ? undefined : value))
+  @Transform(({ value }: { value: unknown }) => (value === '' ? undefined : value))
   @IsUrl()
   thumbnailUrl?: string;
 
@@ -68,7 +68,7 @@ export class CreateProjectDto {
     example: 'https://project-demo.com',
   })
   @IsOptional()
-  @Transform(({ value }) => (value === '' ? undefined : value))
+  @Transform(({ value }: { value: unknown }) => (value === '' ? undefined : value))
   @IsUrl()
   demoUrl?: string;
 


### PR DESCRIPTION
## ⏳ 리뷰 예상 시간

- 1분

## 📝 기능 설명

- 프로젝트 생성 DTO URL 필드에 transform을 추가했어요.
- `@IsOptional()`은 값이 undefined일 때만 검증을 건너뛰는데요.
- 프론트에서 빈 문자열 ""을 보내면 undefined가 아니라서 `@IsUrl()` 검증이 실행되고 실패하게 돼요.
- 그래서 사용자가 프로젝트를 생성하거나 수정할 때 demo URL을 다 지우고 요청을 보내도 pipe에서 검증 실패가 뜨더라구요.

```ts
  @ApiPropertyOptional({
    description: '데모/배포 URL',
    example: 'https://project-demo.com',
  })
  @IsOptional()
  @Transform(({ value }) => (value === '' ? undefined : value))
  @IsUrl()
  demoUrl?: string;
```

## ⭐️ 리뷰 포인트

<!-- 리뷰 포인트를 작성해주세요 -->

## 🛠 작업 사항

<!-- 구현한 작업 내용을 설명해주세요 -->

## ✅ 작업 체크리스트

- [ ] 작업 1
- [ ] 작업 2

## 📎 개발 일지 및 참고 자료

<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 프로젝트 생성 시 썸네일 및 데모 URL 필드에 빈 문자열을 입력해도 유효성 검사에서 적절히 처리되어 오류 없이 생성됩니다.
* **스타일**
  * 내부 코드 서식이 일부 정리되어 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->