### PR TITLE
[Hotfix] 프로젝트 수정 시 demo URL이 빈 문자열일 경우 null로 치환

### DIFF
--- a/BE/src/project/dto/create-project.dto.ts
+++ b/BE/src/project/dto/create-project.dto.ts
@@ -68,7 +68,7 @@ export class CreateProjectDto {
     example: 'https://project-demo.com',
   })
   @IsOptional()
-  @Transform(({ value }: { value: unknown }) => (value === '' ? undefined : value))
+  @Transform(({ value }: { value: unknown }) => (value === '' ? null : value))
   @IsUrl()
   demoUrl?: string;
 


### PR DESCRIPTION
- close #123

## ⏳ 리뷰 예상 시간

<!-- 리뷰 예상 소요 시간을 작성해주세요 -->

## 📝 기능 설명

- 프로젝트 수정 시 demo URL이 빈 문자열일 경우 null로 치환하도록 했어요.
- 기존에는 빈 문자열일 경우 `undefined`로 치환시켰는데 이렇게 될 경우, repository에서 undefined인 값은 update 시키지 않게 설계해두어서 문제가 돼요.
- 그래서 undefined 대신 null로 치환시켜서 사용자가 데모 URL을 삭제할 경우, 데이터베이스에도 null로 들어가도록 했습니다!

## ⭐️ 리뷰 포인트

<!-- 리뷰 포인트를 작성해주세요 -->

## 🛠 작업 사항

<!-- 구현한 작업 내용을 설명해주세요 -->

## ✅ 작업 체크리스트

- [ ] 작업 1
- [ ] 작업 2

## 📎 개발 일지 및 참고 자료

<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 데모 URL 필드의 빈 문자열 처리 방식을 개선했습니다. 빈 입력값이 더 일관되게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->