### PR TITLE
[Refactor] Swagger 데코레이터 분리 및 설정 모듈화

### DIFF
--- a/BE/src/config/swagger/project-swagger.decorator.ts
+++ b/BE/src/config/swagger/project-swagger.decorator.ts
@@ -1,0 +1,275 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+} from '@nestjs/swagger';
+import { CreateProjectDto } from 'src/project/dto/create-project.dto';
+import { ProjectDetailItemDto } from 'src/project/dto/project-detail-item.dto';
+import { ProjectParticipantDto } from 'src/project/dto/project-participant.dto';
+import { ProjectListItemDto } from 'src/project/dto/project-list-item.dto';
+import { UpdateProjectDto } from 'src/project/dto/update-project.dto';
+import { ProjectField } from 'src/project/type/project-field.type';
+
+export function GetAllProjectSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '프로젝트 목록 조회',
+      description: '프로젝트 목록을 조회합니다.',
+    }),
+    ApiQuery({
+      name: 'cohort',
+      required: false,
+      type: Number,
+      description: '부스트캠프 기수 필터',
+      example: 10,
+    }),
+    ApiQuery({
+      name: 'field',
+      required: false,
+      enum: ProjectField,
+      description: '프로젝트 분야 필터',
+      example: ProjectField.WEB,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '프로젝트 목록 조회 성공',
+      type: [ProjectListItemDto],
+    }),
+  );
+}
+
+export function GetProjectSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '프로젝트 단일 조회',
+      description: '특정 프로젝트의 상세 정보를 조회합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '프로젝트 ID',
+      example: 1,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '프로젝트 상세 조회 성공',
+      type: ProjectDetailItemDto,
+    }),
+    ApiResponse({
+      status: 404,
+      description: '프로젝트를 찾을 수 없음',
+    }),
+  );
+}
+
+export function CreateProjectSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '프로젝트 생성',
+      description: '새로운 프로젝트를 생성합니다.',
+    }),
+    ApiBody({
+      type: CreateProjectDto,
+    }),
+    ApiResponse({
+      status: 201,
+      description: '프로젝트 생성 성공',
+      type: ProjectDetailItemDto,
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청',
+    }),
+    ApiResponse({
+      status: 401,
+      description: '인증 필요',
+    }),
+  );
+}
+
+export function UpdateProjectSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '프로젝트 수정',
+      description: '특정 프로젝트를 수정합니다. participants와 techStack은 전체 교체됩니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '프로젝트 ID',
+      example: 1,
+    }),
+    ApiBody({
+      type: UpdateProjectDto,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '프로젝트 수정 성공',
+      type: ProjectDetailItemDto,
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청',
+    }),
+    ApiResponse({
+      status: 404,
+      description: '프로젝트를 찾을 수 없음',
+    }),
+    ApiResponse({
+      status: 401,
+      description: '인증 필요',
+    }),
+    ApiResponse({
+      status: 403,
+      description: '수정 권한 없음',
+    }),
+  );
+}
+
+export function DeleteProjectSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '프로젝트 삭제',
+      description: '특정 프로젝트를 삭제합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '프로젝트 ID',
+      example: 1,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '프로젝트 삭제 성공',
+    }),
+    ApiResponse({
+      status: 404,
+      description: '프로젝트를 찾을 수 없음',
+    }),
+    ApiResponse({
+      status: 401,
+      description: '인증 필요',
+    }),
+    ApiResponse({
+      status: 403,
+      description: '삭제 권한 없음',
+    }),
+  );
+}
+
+export function UploadImageSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '프로젝트 썸네일 임시 업로드',
+      description:
+        '프로젝트 썸네일 이미지를 임시 업로드하고, 생성/수정 시 사용할 uploadId와 사용자에게 보여줄 URL을 반환합니다.',
+    }),
+    ApiConsumes('multipart/form-data'),
+    ApiBody({
+      schema: {
+        type: 'object',
+        properties: {
+          file: {
+            type: 'string',
+            format: 'binary',
+            description: '업로드할 이미지 파일',
+          },
+        },
+        required: ['file'],
+      },
+    }),
+    ApiResponse({
+      status: 201,
+      description: '썸네일 임시 업로드 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          thumbnailUploadId: {
+            type: 'string',
+            example: 'cc67be56-9026-4600-8444-b9c1fe399cf0',
+          },
+          thumbnailUrl: {
+            type: 'string',
+            example:
+              'https://kr.object.ncloudstorage.com/my-bucket/temp/projects/thumbnail/cc67be56-9026-4600-8444-b9c1fe399cf0.png',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청',
+    }),
+    ApiResponse({
+      status: 401,
+      description: '인증 필요',
+    }),
+  );
+}
+
+export function GetCollaboratorSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Github 레포지토리에서 collaborator 목록 조회',
+      description: '쿼리 파라미터로 전달된 GitHub 레포지토리의 collaborator 목록을 조회합니다.',
+    }),
+    ApiQuery({
+      name: 'repository',
+      required: true,
+      type: String,
+      description: 'GitHub repository URL 또는 owner/repo slug',
+      example: 'https://github.com/octocat/Hello-World',
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'collaborator 목록 조회 성공',
+      type: [ProjectParticipantDto],
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 repository 파라미터',
+    }),
+  );
+}
+
+export function GetReadmeSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '레포지토리 README 조회',
+      description: '쿼리 파라미터로 전달된 GitHub 레포지토리의 README 본문을 가져옵니다.',
+    }),
+    ApiQuery({
+      name: 'repository',
+      required: true,
+      type: String,
+      description: 'GitHub repository URL 또는 owner/repo slug',
+      example: 'https://github.com/octocat/Hello-World',
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'README 조회 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', example: 'README.md' },
+          path: { type: 'string', example: 'README.md' },
+          htmlUrl: { type: 'string', example: 'https://github.com/org/repo/blob/main/README.md' },
+          downloadUrl: {
+            type: 'string',
+            example: 'https://raw.githubusercontent.com/org/repo/main/README.md',
+            nullable: true,
+          },
+          encoding: { type: 'string', example: 'utf-8' },
+          content: { type: 'string', description: 'README 본문 문자열' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 repository 파라미터',
+    }),
+  );
+}

--- a/BE/src/config/swagger/project-swagger.decorator.ts
+++ b/BE/src/config/swagger/project-swagger.decorator.ts
@@ -4,23 +4,32 @@ import { applyDecorators } from '@nestjs/common';
 import {
   ApiBody,
   ApiConsumes,
+  ApiExtraModels,
   ApiOperation,
   ApiParam,
   ApiQuery,
   ApiResponse,
+  getSchemaPath,
 } from '@nestjs/swagger';
+import { CommonResponseDto } from 'src/common/dto/common-response.dto';
 import { CreateProjectDto } from 'src/project/dto/create-project.dto';
 import { ProjectDetailItemDto } from 'src/project/dto/project-detail-item.dto';
 import { ProjectParticipantDto } from 'src/project/dto/project-participant.dto';
 import { ProjectListItemDto } from 'src/project/dto/project-list-item.dto';
 import { UpdateProjectDto } from 'src/project/dto/update-project.dto';
 import { ProjectField } from 'src/project/type/project-field.type';
+import {
+  errorResponseSchema,
+  successResponseSchema,
+} from 'src/config/swagger/swagger-response.schema';
 
 export function GetAllProjectSwagger() {
   return applyDecorators(
+    ApiExtraModels(CommonResponseDto, ProjectListItemDto),
     ApiOperation({
       summary: '프로젝트 목록 조회',
-      description: '프로젝트 목록을 조회합니다.',
+      description:
+        '프로젝트 목록을 조회합니다. cohort(기수), field(분야) 조건으로 필터링할 수 있으며, 응답 data는 items와 meta로 구성됩니다.',
     }),
     ApiQuery({
       name: 'cohort',
@@ -39,39 +48,68 @@ export function GetAllProjectSwagger() {
     ApiResponse({
       status: 200,
       description: '프로젝트 목록 조회 성공',
-      type: [ProjectListItemDto],
+      schema: successResponseSchema({
+        type: 'object',
+        properties: {
+          items: {
+            type: 'array',
+            items: { $ref: getSchemaPath(ProjectListItemDto) },
+          },
+          meta: {
+            type: 'object',
+            description: '추가 메타 정보',
+            example: {},
+          },
+        },
+        required: ['items', 'meta'],
+      }),
+    }),
+    ApiResponse({
+      status: 400,
+      description: '쿼리 파라미터 검증 실패',
+      schema: errorResponseSchema(400, 'VALIDATION_ERROR', '입력값이 유효하지 않습니다.'),
     }),
   );
 }
 
 export function GetProjectSwagger() {
   return applyDecorators(
+    ApiExtraModels(CommonResponseDto, ProjectDetailItemDto),
     ApiOperation({
-      summary: '프로젝트 단일 조회',
-      description: '특정 프로젝트의 상세 정보를 조회합니다.',
+      summary: '프로젝트 상세 조회',
+      description: '프로젝트 ID로 상세 정보를 조회합니다.',
     }),
     ApiParam({
       name: 'id',
       description: '프로젝트 ID',
       example: 1,
+      schema: { type: 'integer', minimum: 1 },
     }),
     ApiResponse({
       status: 200,
       description: '프로젝트 상세 조회 성공',
-      type: ProjectDetailItemDto,
+      schema: successResponseSchema({ $ref: getSchemaPath(ProjectDetailItemDto) }),
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'path 파라미터 검증 실패',
+      schema: errorResponseSchema(400, 'VALIDATION_ERROR', '입력값이 유효하지 않습니다.'),
     }),
     ApiResponse({
       status: 404,
       description: '프로젝트를 찾을 수 없음',
+      schema: errorResponseSchema(404, 'PROJECT_NOT_FOUND', '프로젝트를 찾을 수 없습니다.'),
     }),
   );
 }
 
 export function CreateProjectSwagger() {
   return applyDecorators(
+    ApiExtraModels(CommonResponseDto, CreateProjectDto, ProjectDetailItemDto),
     ApiOperation({
       summary: '프로젝트 생성',
-      description: '새로운 프로젝트를 생성합니다.',
+      description:
+        '새로운 프로젝트를 생성합니다. thumbnailUploadId를 전달하면 검증 후 임시 썸네일을 최종 썸네일로 확정합니다.',
     }),
     ApiBody({
       type: CreateProjectDto,
@@ -79,29 +117,52 @@ export function CreateProjectSwagger() {
     ApiResponse({
       status: 201,
       description: '프로젝트 생성 성공',
-      type: ProjectDetailItemDto,
+      schema: successResponseSchema({ $ref: getSchemaPath(ProjectDetailItemDto) }),
     }),
     ApiResponse({
       status: 400,
       description: '잘못된 요청',
+      schema: errorResponseSchema(400, 'VALIDATION_ERROR', '입력값이 유효하지 않습니다.'),
     }),
     ApiResponse({
       status: 401,
       description: '인증 필요',
+      schema: errorResponseSchema(401, 'UNAUTHORIZED', '인증이 필요합니다.'),
+    }),
+    ApiResponse({
+      status: 403,
+      description: '썸네일 소유권 불일치',
+      schema: errorResponseSchema(
+        403,
+        'THUMBNAIL_OWNERSHIP_MISMATCH',
+        '본인이 업로드한 썸네일이 아닙니다.',
+      ),
+    }),
+    ApiResponse({
+      status: 404,
+      description: '썸네일 업로드 정보 또는 사용자 없음',
+      schema: errorResponseSchema(
+        404,
+        'THUMBNAIL_UPLOAD_NOT_FOUND',
+        '썸네일 업로드 정보를 찾을 수 없습니다.',
+      ),
     }),
   );
 }
 
 export function UpdateProjectSwagger() {
   return applyDecorators(
+    ApiExtraModels(CommonResponseDto, UpdateProjectDto, ProjectDetailItemDto),
     ApiOperation({
       summary: '프로젝트 수정',
-      description: '특정 프로젝트를 수정합니다. participants와 techStack은 전체 교체됩니다.',
+      description:
+        '특정 프로젝트를 부분 수정합니다. participants와 techStack을 전달하면 기존 값은 전달된 목록으로 전체 교체됩니다.',
     }),
     ApiParam({
       name: 'id',
       description: '프로젝트 ID',
       example: 1,
+      schema: { type: 'integer', minimum: 1 },
     }),
     ApiBody({
       type: UpdateProjectDto,
@@ -109,63 +170,93 @@ export function UpdateProjectSwagger() {
     ApiResponse({
       status: 200,
       description: '프로젝트 수정 성공',
-      type: ProjectDetailItemDto,
+      schema: successResponseSchema({ $ref: getSchemaPath(ProjectDetailItemDto) }),
     }),
     ApiResponse({
       status: 400,
       description: '잘못된 요청',
+      schema: errorResponseSchema(400, 'VALIDATION_ERROR', '입력값이 유효하지 않습니다.'),
     }),
     ApiResponse({
       status: 404,
       description: '프로젝트를 찾을 수 없음',
+      schema: errorResponseSchema(404, 'PROJECT_NOT_FOUND', '프로젝트를 찾을 수 없습니다.'),
     }),
     ApiResponse({
       status: 401,
       description: '인증 필요',
+      schema: errorResponseSchema(401, 'UNAUTHORIZED', '인증이 필요합니다.'),
     }),
     ApiResponse({
       status: 403,
       description: '수정 권한 없음',
+      schema: errorResponseSchema(
+        403,
+        'PROJECT_FORBIDDEN',
+        '이 프로젝트를 수정할 권한이 없습니다.',
+      ),
     }),
   );
 }
 
 export function DeleteProjectSwagger() {
   return applyDecorators(
+    ApiExtraModels(CommonResponseDto),
     ApiOperation({
       summary: '프로젝트 삭제',
-      description: '특정 프로젝트를 삭제합니다.',
+      description: '특정 프로젝트를 삭제합니다. 관리자 권한이 필요합니다.',
     }),
     ApiParam({
       name: 'id',
       description: '프로젝트 ID',
       example: 1,
+      schema: { type: 'integer', minimum: 1 },
     }),
     ApiResponse({
       status: 200,
       description: '프로젝트 삭제 성공',
+      schema: successResponseSchema({
+        type: 'object',
+        properties: {
+          id: { type: 'number', example: 1 },
+        },
+        required: ['id'],
+      }),
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'path 파라미터 검증 실패',
+      schema: errorResponseSchema(400, 'VALIDATION_ERROR', '입력값이 유효하지 않습니다.'),
     }),
     ApiResponse({
       status: 404,
       description: '프로젝트를 찾을 수 없음',
+      schema: errorResponseSchema(404, 'PROJECT_NOT_FOUND', '프로젝트를 찾을 수 없습니다.'),
     }),
     ApiResponse({
       status: 401,
       description: '인증 필요',
+      schema: errorResponseSchema(401, 'UNAUTHORIZED', '인증이 필요합니다.'),
     }),
     ApiResponse({
       status: 403,
       description: '삭제 권한 없음',
+      schema: errorResponseSchema(
+        403,
+        'PROJECT_FORBIDDEN',
+        '이 프로젝트를 삭제할 권한이 없습니다.',
+      ),
     }),
   );
 }
 
 export function UploadImageSwagger() {
   return applyDecorators(
+    ApiExtraModels(CommonResponseDto),
     ApiOperation({
       summary: '프로젝트 썸네일 임시 업로드',
       description:
-        '프로젝트 썸네일 이미지를 임시 업로드하고, 생성/수정 시 사용할 uploadId와 사용자에게 보여줄 URL을 반환합니다.',
+        '프로젝트 썸네일 이미지를 multipart/form-data로 임시 업로드하고, 생성/수정에서 사용할 thumbnailUploadId와 thumbnailUrl을 반환합니다.',
     }),
     ApiConsumes('multipart/form-data'),
     ApiBody({
@@ -184,7 +275,7 @@ export function UploadImageSwagger() {
     ApiResponse({
       status: 201,
       description: '썸네일 임시 업로드 성공',
-      schema: {
+      schema: successResponseSchema({
         type: 'object',
         properties: {
           thumbnailUploadId: {
@@ -197,61 +288,85 @@ export function UploadImageSwagger() {
               'https://kr.object.ncloudstorage.com/my-bucket/temp/projects/thumbnail/cc67be56-9026-4600-8444-b9c1fe399cf0.png',
           },
         },
-      },
+        required: ['thumbnailUploadId', 'thumbnailUrl'],
+      }),
     }),
     ApiResponse({
       status: 400,
       description: '잘못된 요청',
+      schema: errorResponseSchema(400, 'VALIDATION_ERROR', '입력값이 유효하지 않습니다.'),
     }),
     ApiResponse({
       status: 401,
       description: '인증 필요',
+      schema: errorResponseSchema(401, 'UNAUTHORIZED', '인증이 필요합니다.'),
     }),
   );
 }
 
 export function GetCollaboratorSwagger() {
   return applyDecorators(
+    ApiExtraModels(CommonResponseDto, ProjectParticipantDto),
     ApiOperation({
       summary: 'Github 레포지토리에서 collaborator 목록 조회',
-      description: '쿼리 파라미터로 전달된 GitHub 레포지토리의 collaborator 목록을 조회합니다.',
+      description:
+        'repository 쿼리(owner/repo 또는 URL)로 전달된 GitHub 레포지토리의 collaborator 목록을 조회합니다.',
     }),
     ApiQuery({
       name: 'repository',
       required: true,
       type: String,
-      description: 'GitHub repository URL 또는 owner/repo slug',
-      example: 'https://github.com/octocat/Hello-World',
+      description: 'GitHub repository URL',
+      example: 'https://github.com/boostcampw2025/web01-boostus',
     }),
     ApiResponse({
       status: 200,
       description: 'collaborator 목록 조회 성공',
-      type: [ProjectParticipantDto],
+      schema: successResponseSchema({
+        type: 'array',
+        items: { $ref: getSchemaPath(ProjectParticipantDto) },
+      }),
     }),
     ApiResponse({
       status: 400,
       description: '잘못된 repository 파라미터',
+      schema: errorResponseSchema(
+        400,
+        'INVALID_REPOSITORY_URL',
+        'repositoryUrl 형식이 올바르지 않습니다.',
+      ),
+    }),
+    ApiResponse({
+      status: 502,
+      description: 'GitHub API 요청 실패',
+      schema: errorResponseSchema(
+        502,
+        'GITHUB_API_REQUEST_FAILED',
+        'GitHub API 요청에 실패했습니다.',
+      ),
     }),
   );
 }
 
 export function GetReadmeSwagger() {
   return applyDecorators(
+    ApiExtraModels(CommonResponseDto),
     ApiOperation({
       summary: '레포지토리 README 조회',
-      description: '쿼리 파라미터로 전달된 GitHub 레포지토리의 README 본문을 가져옵니다.',
+      description:
+        'repository 쿼리(owner/repo 또는 URL)로 전달된 GitHub 레포지토리의 README 메타데이터와 본문을 조회합니다.',
     }),
     ApiQuery({
       name: 'repository',
       required: true,
       type: String,
-      description: 'GitHub repository URL 또는 owner/repo slug',
-      example: 'https://github.com/octocat/Hello-World',
+      description: 'GitHub repository URL',
+      example: 'https://github.com/boostcampw2025/web01-boostus',
     }),
     ApiResponse({
       status: 200,
       description: 'README 조회 성공',
-      schema: {
+      schema: successResponseSchema({
         type: 'object',
         properties: {
           name: { type: 'string', example: 'README.md' },
@@ -265,11 +380,26 @@ export function GetReadmeSwagger() {
           encoding: { type: 'string', example: 'utf-8' },
           content: { type: 'string', description: 'README 본문 문자열' },
         },
-      },
+        required: ['name', 'path', 'htmlUrl', 'encoding', 'content'],
+      }),
     }),
     ApiResponse({
       status: 400,
       description: '잘못된 repository 파라미터',
+      schema: errorResponseSchema(
+        400,
+        'INVALID_REPOSITORY_URL',
+        'repositoryUrl 형식이 올바르지 않습니다.',
+      ),
+    }),
+    ApiResponse({
+      status: 502,
+      description: 'GitHub API 요청 실패',
+      schema: errorResponseSchema(
+        502,
+        'GITHUB_API_REQUEST_FAILED',
+        'GitHub API 요청에 실패했습니다.',
+      ),
     }),
   );
 }

--- a/BE/src/config/swagger/swagger-response.schema.ts
+++ b/BE/src/config/swagger/swagger-response.schema.ts
@@ -1,0 +1,53 @@
+import { getSchemaPath } from '@nestjs/swagger';
+import { CommonResponseDto } from 'src/common/dto/common-response.dto';
+
+/**
+ * 성공 응답을 기존에 사용하던 공통 래퍼(CommonResponseDto) 형태로 구성합니다.
+ * `dataSchema`에는 엔드포인트별 실제 data 구조(객체/배열/DTO ref)를 전달합니다.
+ */
+export const successResponseSchema = (dataSchema: Record<string, unknown>) => ({
+  allOf: [
+    { $ref: getSchemaPath(CommonResponseDto) }, // "#/components/schemas/CommonResponseDto"
+    {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean', example: true },
+        message: { type: 'string', example: '성공적으로 응답되었습니다.' },
+        error: { nullable: true, example: null },
+        data: dataSchema,
+      },
+    },
+  ],
+});
+
+/**
+ * 실패 응답 스키마를 공통 에러 포맷으로 구성합니다.
+ * status/code/message는 예외 필터가 내려주는 error 객체의 기본 값을 문서화할 때 사용합니다.
+ */
+export const errorResponseSchema = (
+  status: number,
+  code: string,
+  message: string,
+  details?: Record<string, unknown>,
+) => ({
+  type: 'object',
+  properties: {
+    success: { type: 'boolean', example: false },
+    error: {
+      type: 'object',
+      properties: {
+        code: { type: 'string', example: code },
+        message: { type: 'string', example: message },
+        status: { type: 'number', example: status },
+        details: {
+          type: 'object',
+          nullable: true,
+          example: details ?? null,
+        },
+      },
+      required: ['code', 'message', 'status'],
+    },
+    data: { nullable: true, example: null },
+  },
+  required: ['success', 'error', 'data'],
+});

--- a/BE/src/config/swagger/swagger.config.ts
+++ b/BE/src/config/swagger/swagger.config.ts
@@ -10,6 +10,7 @@ export function setupSwagger(app: INestApplication): void {
   const document = SwaggerModule.createDocument(app, config);
 
   SwaggerModule.setup('api/api-docs', app, document, {
+    jsonDocumentUrl: 'api/api-docs/json',
     swaggerOptions: {
       defaultModelsExpandDepth: 5,
       defaultModelExpandDepth: 5,

--- a/BE/src/config/swagger/swagger.config.ts
+++ b/BE/src/config/swagger/swagger.config.ts
@@ -1,0 +1,18 @@
+import { INestApplication } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
+export function setupSwagger(app: INestApplication): void {
+  const config = new DocumentBuilder()
+    .setTitle('boostus')
+    .setDescription('boostus API 명세서')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+
+  SwaggerModule.setup('api/api-docs', app, document, {
+    swaggerOptions: {
+      defaultModelsExpandDepth: 5,
+      defaultModelExpandDepth: 5,
+    },
+  });
+}

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -1,6 +1,6 @@
 import { ValidationPipe } from '@nestjs/common';
 import { NestFactory, Reflector } from '@nestjs/core';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { setupSwagger } from './config/swagger/swagger.config';
 import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
 import { ResponseInterceptor } from './common/interceptor/response.interceptor';
@@ -56,14 +56,7 @@ async function bootstrap() {
     }),
   );
 
-  // 스웨거 설정
-  const config = new DocumentBuilder()
-    .setTitle('BoostUs API')
-    .setDescription('BoostUs API Description')
-    .setVersion('1.0')
-    .build();
-  const documentFactory = () => SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, documentFactory);
+  setupSwagger(app);
 
   await app.listen(process.env.PORT ?? 3000);
 }

--- a/BE/src/project/project.controller.ts
+++ b/BE/src/project/project.controller.ts
@@ -38,6 +38,19 @@ import {
 @Controller('projects')
 export class ProjectController {
   constructor(private readonly projectService: ProjectService) {}
+  @Public()
+  @Get('/collaborators')
+  @GetCollaboratorSwagger()
+  async getCollaborators(@Query('repository') repositoryUrl: string) {
+    return this.projectService.getRepoCollaborators(repositoryUrl);
+  }
+
+  @Public()
+  @Get('/readme')
+  @GetReadmeSwagger()
+  async getReadme(@Query('repository') repositoryUrl: string) {
+    return this.projectService.getRepoReadme(repositoryUrl);
+  }
 
   @Public()
   @Get()
@@ -84,19 +97,5 @@ export class ProjectController {
     @UploadedFile() file: Express.Multer.File,
   ) {
     return this.projectService.uploadTempThumbnail(file, memberId);
-  }
-
-  @Public()
-  @Get('/collaborators')
-  @GetCollaboratorSwagger()
-  async getCollaborators(@Query('repository') repositoryUrl: string) {
-    return this.projectService.getRepoCollaborators(repositoryUrl);
-  }
-
-  @Public()
-  @Get('/readme')
-  @GetReadmeSwagger()
-  async getReadme(@Query('repository') repositoryUrl: string) {
-    return this.projectService.getRepoReadme(repositoryUrl);
   }
 }

--- a/BE/src/project/project.controller.ts
+++ b/BE/src/project/project.controller.ts
@@ -13,25 +13,71 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { Public } from '../auth/decorator/public.decorator';
 import { CreateProjectDto } from './dto/create-project.dto';
-import { ProjectDetailItemDto } from './dto/project-detail-item.dto';
-import { ProjectListItemDto } from './dto/project-list-item.dto';
 import { ProjectListQueryDto } from './dto/project-list-query.dto';
-import { ProjectParticipantDto } from './dto/project-participant.dto';
 import { UpdateProjectDto } from './dto/update-project.dto';
 import { ProjectService } from './project.service';
 import { CurrentMember } from 'src/auth/decorator/current-member.decorator';
 import { ViewerKeyGuard } from 'src/view/guard/view.guard';
 import { ViewerKey } from 'src/view/decorator/viewer-key.decorator';
 
+import {
+  GetProjectSwagger,
+  GetAllProjectSwagger,
+  CreateProjectSwagger,
+  UpdateProjectSwagger,
+  DeleteProjectSwagger,
+  UploadImageSwagger,
+  GetCollaboratorSwagger,
+  GetReadmeSwagger,
+} from 'src/config/swagger/project-swagger.decorator';
+
 @ApiTags('프로젝트')
 @Controller('projects')
 export class ProjectController {
   constructor(private readonly projectService: ProjectService) {}
 
+  @Public()
+  @Get()
+  @GetAllProjectSwagger()
+  findAll(@Query() query: ProjectListQueryDto) {
+    return this.projectService.findAll(query);
+  }
+
+  @Public()
+  @UseGuards(ViewerKeyGuard)
+  @Get(':id')
+  @GetProjectSwagger()
+  findOne(@Param('id', ParseIntPipe) id: number, @ViewerKey() viewerKey: string) {
+    return this.projectService.findOneWithViewCount(id, viewerKey);
+  }
+
+  @Post()
+  @CreateProjectSwagger()
+  create(@CurrentMember() memberId: bigint, @Body() dto: CreateProjectDto) {
+    return this.projectService.create(memberId, dto);
+  }
+
+  @Patch(':id')
+  @UpdateProjectSwagger()
+  update(
+    @CurrentMember() memberId: bigint,
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateProjectDto,
+  ) {
+    return this.projectService.update(id, memberId, dto);
+  }
+
+  @Delete(':id')
+  @DeleteProjectSwagger()
+  delete(@CurrentMember() memberId: bigint, @Param('id', ParseIntPipe) id: number) {
+    return this.projectService.delete(id, memberId);
+  }
+
   @Post('uploads/thumbnails')
+  @UploadImageSwagger()
   @UseInterceptors(FileInterceptor('file'))
   async uploadTempThumbnail(
     @CurrentMember() memberId: bigint,
@@ -42,163 +88,15 @@ export class ProjectController {
 
   @Public()
   @Get('/collaborators')
-  @ApiOperation({
-    summary: '레포지토리 collaborator 목록 조회',
-    description:
-      'repository 쿼리 파라미터로 전달된 GitHub 레포지토리의 collaborator 목록을 조회합니다.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'collaborator 목록 조회 성공',
-    type: [ProjectParticipantDto],
-  })
+  @GetCollaboratorSwagger()
   async getCollaborators(@Query('repository') repositoryUrl: string) {
     return this.projectService.getRepoCollaborators(repositoryUrl);
   }
 
   @Public()
   @Get('/readme')
-  @ApiOperation({
-    summary: '레포지토리 README 조회',
-    description: 'repository 쿼리 파라미터로 전달된 GitHub 레포지토리의 README 본문을 가져옵니다.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'README 조회 성공',
-    schema: {
-      type: 'object',
-      properties: {
-        name: { type: 'string', example: 'README.md' },
-        path: { type: 'string', example: 'README.md' },
-        htmlUrl: { type: 'string', example: 'https://github.com/org/repo/blob/main/README.md' },
-        downloadUrl: {
-          type: 'string',
-          example: 'https://raw.githubusercontent.com/org/repo/main/README.md',
-          nullable: true,
-        },
-        encoding: { type: 'string', example: 'utf-8' },
-        content: { type: 'string', description: 'README 본문 문자열' },
-      },
-    },
-  })
+  @GetReadmeSwagger()
   async getReadme(@Query('repository') repositoryUrl: string) {
     return this.projectService.getRepoReadme(repositoryUrl);
-  }
-
-  @Public()
-  @Get()
-  @ApiOperation({
-    summary: '프로젝트 목록 조회',
-    description:
-      '프로젝트 목록을 조회합니다. 페이지네이션, 기수, 기술 스택으로 필터링할 수 있습니다.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '프로젝트 목록 조회 성공',
-    type: [ProjectListItemDto],
-  })
-  findAll(@Query() query: ProjectListQueryDto) {
-    return this.projectService.findAll(query);
-  }
-
-  @Public()
-  @UseGuards(ViewerKeyGuard)
-  @Get(':id')
-  @ApiOperation({
-    summary: '프로젝트 상세 조회',
-    description: '특정 프로젝트의 상세 정보를 조회합니다.',
-  })
-  @ApiParam({
-    name: 'id',
-    description: '프로젝트 ID',
-    example: 1,
-  })
-  @ApiResponse({
-    status: 200,
-    description: '프로젝트 상세 조회 성공',
-    type: ProjectDetailItemDto,
-  })
-  @ApiResponse({
-    status: 404,
-    description: '프로젝트를 찾을 수 없음',
-  })
-  findOne(@Param('id', ParseIntPipe) id: number, @ViewerKey() viewerKey: string) {
-    return this.projectService.findOneWithViewCount(id, viewerKey);
-  }
-
-  @Post()
-  @ApiOperation({
-    summary: '프로젝트 생성',
-    description: '새로운 프로젝트를 생성합니다.',
-  })
-  @ApiBody({
-    type: CreateProjectDto,
-  })
-  @ApiResponse({
-    status: 201,
-    description: '프로젝트 생성 성공',
-    type: ProjectDetailItemDto,
-  })
-  @ApiResponse({
-    status: 400,
-    description: '잘못된 요청',
-  })
-  create(@CurrentMember() memberId: bigint, @Body() dto: CreateProjectDto) {
-    return this.projectService.create(memberId, dto);
-  }
-
-  @Patch(':id')
-  @ApiOperation({
-    summary: '프로젝트 수정',
-    description: '특정 프로젝트를 수정합니다. participants와 techStack은 전체 교체됩니다.',
-  })
-  @ApiParam({
-    name: 'id',
-    description: '프로젝트 ID',
-    example: 1,
-  })
-  @ApiBody({
-    type: UpdateProjectDto,
-  })
-  @ApiResponse({
-    description: '프로젝트 수정 성공',
-    type: ProjectDetailItemDto,
-  })
-  @ApiResponse({
-    status: 400,
-    description: '잘못된 요청',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '프로젝트를 찾을 수 없음',
-  })
-  update(
-    @CurrentMember() memberId: bigint,
-    @Param('id', ParseIntPipe) id: number,
-    @Body() dto: UpdateProjectDto,
-  ) {
-    return this.projectService.update(id, memberId, dto);
-  }
-
-  @Delete(':id')
-  @ApiOperation({
-    summary: '프로젝트 삭제',
-    description: '특정 프로젝트를 삭제합니다.',
-  })
-  @ApiParam({
-    name: 'id',
-    description: '프로젝트 ID',
-    example: 1,
-  })
-  @ApiResponse({
-    status: 200,
-    description: '프로젝트 삭제 성공',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '프로젝트를 찾을 수 없음',
-  })
-  delete(@CurrentMember() memberId: bigint, @Param('id', ParseIntPipe) id: number) {
-    return this.projectService.delete(id, memberId);
   }
 }

--- a/BE/src/project/project.service.ts
+++ b/BE/src/project/project.service.ts
@@ -108,7 +108,7 @@ export class ProjectService {
    * @param repositoryUrl GitHub 레포 URL 또는 slug
    * @returns { owner, repo }
    */
-  private _parseRepositorySlug(repositoryUrl: string) {
+  private _parseRepositorySlug(repositoryUrl: string): { owner: string; repo: string } {
     const raw = repositoryUrl.trim();
     let path = raw;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,6 +45,10 @@ http {
     # 최대 요청 바디 크기 설정
     client_max_body_size 10M;
 
+    location /api/api-docs {
+      deny all;
+    }
+
     location /api/ {
       proxy_pass http://backend;
 


### PR DESCRIPTION
- close #375

## ⏳ 리뷰 예상 시간

- 5분 내외

## 📝 기능 설명

- 기존 컨트롤러에 스웨거 문서 설정 데코레이터가 너무 두꺼워, 가독성이 매우 떨어지는 문제가 있었습니다.
- 또한 `main.ts` 에 pipe, cors, swagger 등 여러 설정 코드가 그대로 들어있어, 별도의 설정 파일로 분리해 가볍게 만들고자 했습니다.

## ⭐️ 리뷰 포인트

- NestJS 내장 유틸함수인 `applyDecorators()` 를 이용해 `@ApiOperation()`, `@ApiResponse()` 등을 `@GetAllProjectSwagger()` <- 이런 식으로 하나로 묶어서 사용하도록 했습니다.
- 따라서 컨트롤러 자체의 가독성은 좋아지지만, 엔드포인트마다 하나의 데코레이터를 별도로 정의해야 하고 컨트롤러에서 모두 import 해야 하기에 상단 선언부가 길어진다는 트레이드오프가 존재합니다.
  - 그럼에도 `컨트롤러에 스웨거 데코레이터가 너무 길어 가독성이 떨어진다'는 문제상황 해결 방안으로는 충분히 채택 가능하다고 봅니다!

## 🛠 작업 사항

- 스웨거 설정을 `main.ts` 에서 `config/swagger/swagger.config.ts` 로 분리하여 main.ts 간소화
- 스웨거 uri 를 `/api` 에서 `/api/api-docs` 로 변경
  - nginx 단에서 `/api/api-docs` 외부 접근 차단할 수 있도록
- `project-swagger.decorator.ts` 를 생성하고 프로젝트 도메인 스웨거 데코레이터 별도로 분리
- 스웨거 데코레이터 별로 어떤 요소를 달아주는지 학습정리한 뒤 정리한 내용을 바탕으로 `swagger.agent.md` 를 작성했고, 이 문서를 바탕으로 Codex 에게 작업을 시켰습니다.


## 📎 개발 일지 및 참고 자료

- [학습정리 및 swagger.agent.md](https://gist.github.com/LimSR12/c274233896de286490255d23c9ec4085)
- [nestjs 컨트롤러 라우팅 순서로 인한 에러](https://github.com/LimSR12/TIL/blob/main/nestjs/%EC%BB%A8%ED%8A%B8%EB%A1%A4%EB%9F%AC%20%EB%9D%BC%EC%9A%B0%ED%8C%85%20%EC%88%9C%EC%84%9C.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * 프로젝트 썸네일(임시) 업로드 엔드포인트 추가
  * 협력자 조회 및 README 조회 엔드포인트 공개/정비

* **Documentation**
  * Swagger 기반 API 문서 설정을 중앙화하고 API 문서 경로 및 UI 구성 추가
  * 프로젝트 관련 엔드포인트별 API 문서 데코레이터 및 성공/오류 응답 스키마 표준화

* **Refactor**
  * 내부 타입 안정성 개선으로 일부 반환 구조 명확화

* **Chores**
  * 운영 환경에서 API 문서 경로 접근 차단(요청 시 403 반환)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->