### PR TITLE
[Feat] 조회수 처리 방식 변경 (즉시 UPDATE → Redis 카운터 누적 후 배치)

### DIFF
--- a/BE/docs/swagger.md
+++ b/BE/docs/swagger.md
@@ -1,0 +1,275 @@
+# Swagger 문서화 가이드 (NestJS + applyDecorators 기반)
+
+> 목적: 컨트롤러 메서드에 Swagger 데코레이터를 두껍게 붙이지 않고, 엔드포인트별 **단일 커스텀 데코레이터**(`@GetProjectSwagger()` 등)로 문서 정확도/일관성을 유지한다.  
+> 원칙: **실제 API 동작(요청/응답/에러/래핑 포맷)과 Swagger 문서가 1:1로 매칭**되어야 한다.
+
+---
+
+## 0) 적용 방식 (필수)
+
+- Swagger 데코레이터는 컨트롤러에서 직접 나열하지 않는다.
+- `src/config/swagger/**/*.decorator.ts` 같은 위치에 **엔드포인트별 decorator 함수**로 분리한다.
+- 각 decorator 함수는 `applyDecorators()`로 묶어서 반환한다.
+
+decorator 함수 예시:
+
+- `GetAllProjectSwagger()`
+- `GetProjectSwagger()`
+- `CreateProjectSwagger()`
+- `UpdateProjectSwagger()`
+- `DeleteProjectSwagger()`
+- `UploadImageSwagger()`
+
+---
+
+## 1) applyDecorators 규칙
+
+### 1.1 기본 형태
+
+- 엔드포인트 1개당 decorator 함수 1개
+- 함수명은 `Action + Resource + Swagger`로 통일
+
+예:
+
+- `GetAllProjectSwagger`
+- `GetProjectSwagger`
+- `CreateProjectSwagger`
+- `UploadProjectThumbnailSwagger`
+
+### 1.2 applyDecorators 내부 구성 순서
+
+아래 순서로 나열해 가독성을 고정한다.
+
+1. `ApiOperation`
+2. `ApiParam` (있다면)
+3. `ApiQuery` (있다면)
+4. `ApiConsumes` (파일 업로드일 때)
+5. `ApiBody` (body/파일 업로드일 때)
+6. `ApiResponse` 계열 (성공 응답 → 에러 응답 순)
+
+---
+
+## 2) Swagger 데코레이터별 사용 원칙
+
+### 2.1 ApiOperation (모든 엔드포인트 필수)
+
+- `summary`: 목록에서 보이는 한 줄 설명
+- `description`: 핵심 비즈니스 규칙/제약/필터/교체 규칙을 문장으로 명시
+
+권장 규칙:
+
+- summary: `동사 + 대상` (짧게)
+  - 예: `프로젝트 목록 조회`, `프로젝트 상세 조회`, `프로젝트 생성`
+- description: "무엇을/어떻게/제약"을 구체적으로
+  - 예: pagination, 필터 조건, 전체 교체/부분 수정 규칙, 권한 조건 등
+
+---
+
+### 2.2 ApiParam (path param 있을 때 필수)
+
+- `/:id` 같은 Path Parameter 문서화
+
+규칙:
+
+- `name`은 실제 라우트 파라미터와 동일
+- `description`에 의미를 명확히
+- `example` 또는 `schema`로 타입/예시를 분명히
+
+---
+
+### 2.3 ApiQuery (query param 있을 때 필수)
+
+- 목록 조회/검색/필터에서 query를 받으면, 받는 query를 모두 명시한다.
+
+규칙:
+
+- 실제로 받는 query 파라미터를 `ApiQuery`로 모두 선언한다.
+- description에는 "쿼리로 받는다" 같은 문장 대신 **의미/범위/예시**를 적는다.
+
+---
+
+### 2.4 ApiBody (body가 있는 요청 필수)
+
+- POST/PUT/PATCH 등 request body 문서화
+
+규칙:
+
+- DTO 기반으로 문서화한다: `ApiBody({ type: CreateDto })`
+- schema가 필요 없다면 DTO를 우선한다.
+
+---
+
+### 2.5 ApiConsumes + 파일 업로드 (파일 업로드 엔드포인트 필수)
+
+규칙:
+
+- `ApiConsumes('multipart/form-data')` 필수
+- `ApiBody`에 `file`을 `format: binary`로 명시한다.
+  - 예: `ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' }}, required: ['file'] } })`
+
+---
+
+### 2.6 ApiResponse 계열 (모든 엔드포인트 필수)
+
+- 응답 문서화
+- 통일성 확보를 위해 **status를 항상 명시**한다.
+
+규칙:
+
+- 성공 응답(1개) + 실패 응답(필요한 만큼)
+- 에러 응답은 엔드포인트 특성에 맞게 포함한다.
+  - 예: 400/401/403/404/409/413/415 등
+- 공통 응답 래퍼 포맷을 Swagger에도 반드시 반영한다.
+
+---
+
+## 3) 엔드포인트 유형별 "필수 템플릿"
+
+> 아래 템플릿은 "최소 필수" 기준이다. 인증/권한/중복/용량 등 정책에 따라 에러 응답을 추가한다.
+
+### 3.1 목록 조회 (GET /resources)
+
+필수:
+
+- ApiOperation
+- 200 성공 응답
+
+선택:
+
+- ApiQuery (page/size/필터)
+- pagination meta가 있다면 DTO/Schema로 문서화
+
+---
+
+### 3.2 상세 조회 (GET /resources/:id)
+
+필수:
+
+- ApiOperation
+- ApiParam(id)
+- 200 성공 응답(type=DetailDto)
+- 404 실패 응답
+
+선택:
+
+- 400 파라미터 타입 불일치 (예: id에 숫자 대신 문자열)
+
+---
+
+### 3.3 생성 (POST /resources)
+
+필수:
+
+- ApiOperation
+- ApiBody(CreateDto)
+- 201 성공 응답(type=DetailDto)
+- 400 실패 응답
+
+선택:
+
+- 401/403 (인증/권한)
+- 409 (중복 생성)
+
+---
+
+### 3.4 수정 (PUT/PATCH /resources/:id)
+
+필수:
+
+- ApiOperation
+- ApiParam(id)
+- ApiBody(UpdateDto)
+- 200 성공 응답(또는 204)
+- 400, 404 실패 응답
+
+중요:
+
+- "전체 교체" / "부분 수정" 규칙을 description에 반드시 명시
+
+---
+
+### 3.5 삭제 (DELETE /resources/:id)
+
+필수:
+
+- ApiOperation
+- ApiParam(id)
+- 200 성공 응답(또는 204)
+- 404 실패 응답
+
+---
+
+### 3.6 파일 업로드 (POST /resources/:id/upload)
+
+필수:
+
+- ApiOperation
+- ApiConsumes('multipart/form-data')
+- ApiBody(schema 또는 DTO)
+- 200/201 성공 응답
+- 400 실패 응답
+
+선택:
+
+- 413 (용량 초과)
+- 415 (미지원 미디어 타입)
+
+---
+
+## 4) 공통 응답 래퍼(Wrapper) 반영 규칙 (중요)
+
+- 서버가 공통 응답 포맷으로 래핑한다면 Swagger도 동일하게 래핑한다.
+- Swagger 문서의 응답 스키마가 실제 응답과 다르면 문서는 "오답"이다.
+
+예시(개념):
+
+- 성공: `{ success: true, data: <T>, error: null }`
+- 실패: `{ success: false, data: null, error: { code, message, ... } }`
+
+가이드:
+
+- wrapper를 Swagger 전역 스키마(components.schemas)로 만들고,
+- 각 엔드포인트 응답에서 `data`에 실제 DTO를 매핑한다.
+
+---
+
+## 5) 스웨거 설정 시 권장 옵션(가이드)
+
+- 기본적으로 정렬은 프로젝트 정책에 맞춘다.
+- 문서 정확도(모델 깊이/표시)를 위해 expand depth를 조정한다.
+
+권장:
+
+- `defaultModelsExpandDepth`
+- `defaultModelExpandDepth`
+
+정렬(선택):
+
+- tagsSorter / operationsSorter는 "팀 컨벤션"이 정해졌을 때만 적용한다.
+- 정렬이 문서 가독성을 해치거나 컨트롤러 작성 순서와 어긋나면 적용하지 않는다.
+
+---
+
+## 6) 일관성 체크리스트 (PR 필수 점검)
+
+- [ ] 모든 엔드포인트에 `ApiOperation`이 있는가?
+- [ ] path param이 있으면 `ApiParam`을 선언했는가?
+- [ ] query param이 있으면 `ApiQuery`를 선언했는가?
+- [ ] body가 있으면 `ApiBody`를 선언했는가?
+- [ ] 파일 업로드면 `ApiConsumes('multipart/form-data')` + body schema를 선언했는가?
+- [ ] `ApiResponse`에 status를 항상 명시했는가?
+- [ ] 에러 응답(400/404 등)을 엔드포인트 특성에 맞게 포함했는가?
+- [ ] 문서 내용이 실제 동작과 1:1로 정확히 매칭되는가?
+- [ ] 응답이 공통 래핑 포맷이라면 Swagger도 wrapper를 반영했는가?
+
+---
+
+## 7) agent 작업 지시
+
+agent는 Swagger 작업 시 아래를 반드시 수행한다.
+
+1. 컨트롤러에는 엔드포인트별 **단일 Swagger 데코레이터만** 남긴다.
+2. Swagger 데코레이터는 `applyDecorators()` 기반으로 분리한다.
+3. 요청 파라미터(path/query/body/file)와 응답(성공/실패)이 **실제 동작과 1:1**로 맞도록 문서화한다.
+4. 공통 래퍼 포맷이 있다면 Swagger 응답 스키마도 반드시 래핑하여 문서화한다.
+5. 작업 완료 후 6번의 체크리스트를 모두 통과해야 한다.

--- a/BE/eslint.config.mjs
+++ b/BE/eslint.config.mjs
@@ -48,6 +48,12 @@ export default tseslint.config(
           format: ['camelCase'],
         },
         {
+          // 데코레이터 팩토리 함수: PascalCase 허용 (NestJS 커스텀 데코레이터 컨벤션)
+          selector: 'function',
+          modifiers: ['exported'],
+          format: ['camelCase', 'PascalCase'],
+        },
+        {
           // 클래스: PascalCase
           selector: 'class',
           format: ['PascalCase'],

--- a/BE/load-test/view-1000.js
+++ b/BE/load-test/view-1000.js
@@ -1,0 +1,32 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+/**
+ * 시나리오: id=1 게시글을 처음 보는 서로 다른 사용자 1,000명이 동시 조회
+ *
+ * - vus: 1000, iterations: 1000 → VU당 1번 요청 (최대한 동시에 시작)
+ * - bid 쿠키 없이 요청 → ViewerKeyGuard가 매 요청마다 새 UUID 발급 → 전원 첫 조회 처리
+ * - jar.clear() → VU가 이전 Set-Cookie 응답을 재사용하지 않도록 차단
+ */
+export const options = {
+  vus: 1000,
+  iterations: 1000,
+  thresholds: {
+    http_req_duration: ['p(95)<2000'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+const BASE_URL = 'http://localhost:3000/api';
+const STORY_ID = 1;
+
+export default function () {
+  const jar = http.cookieJar();
+  jar.clear('http://localhost:3000');
+
+  const res = http.post(`${BASE_URL}/stories/${STORY_ID}/view`);
+
+  check(res, {
+    'status 201': (r) => r.status === 201,
+  });
+}

--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.1.1",
         "@nestjs/swagger": "^11.2.5",
         "@prisma/adapter-mariadb": "^7.1.0",
         "@prisma/client": "^7.1.0",
@@ -3882,6 +3883,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.1.tgz",
+      "integrity": "sha512-kQl1RRgi02GJ0uaUGCrXHCcwISsCsJDciCKe38ykJZgnAeeoeVWs8luWtBo4AqAAXm4nS5K8RlV0smHUJ4+2FA==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.9",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.9.tgz",
@@ -5325,6 +5339,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -7367,6 +7387,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -10395,6 +10432,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/BE/package.json
+++ b/BE/package.json
@@ -34,6 +34,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.1.1",
     "@nestjs/swagger": "^11.2.5",
     "@prisma/adapter-mariadb": "^7.1.0",
     "@prisma/client": "^7.1.0",

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Logger, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_FILTER, APP_GUARD } from '@nestjs/core';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AnswerModule } from './answer/answer.module';
 import { AuthModule } from './auth/auth.module';
 import { AuthGuard } from './auth/guard/auth.guard';
@@ -23,6 +24,7 @@ import { TechStackModule } from './tech-stack/tech-stack.module';
     ConfigModule.forRoot({
       isGlobal: true,
     }),
+    ScheduleModule.forRoot(),
     FeedModule,
     StoryModule,
     QuestionModule,

--- a/BE/src/config/swagger/project-swagger.decorator.ts
+++ b/BE/src/config/swagger/project-swagger.decorator.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { applyDecorators } from '@nestjs/common';
 import {
   ApiBody,

--- a/BE/src/config/swagger/question-swagger.decorator.ts
+++ b/BE/src/config/swagger/question-swagger.decorator.ts
@@ -1,0 +1,177 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiExtraModels, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { CreateQuestionDto } from 'src/question/dto/req/create-question.dto';
+import { UpdateQuestionDto } from 'src/question/dto/req/update-question.dto';
+import { QuestionDetailItemDto } from 'src/question/dto/res/detail/question-detail-item.dto';
+import { QuestionResponseDto } from 'src/question/dto/res/detail/question-response.dto';
+import { QuestionCursorResponseDto } from 'src/question/dto/res/all/question-list.dto';
+import { QuestionCountDto } from 'src/question/dto/res/question-count.dto';
+
+export function CreateQuestionSwagger() {
+  return applyDecorators(
+    ApiExtraModels(CreateQuestionDto),
+    ApiOperation({
+      summary: '질문 생성',
+      description: '새로운 질문을 생성합니다.',
+    }),
+    ApiBody({
+      type: CreateQuestionDto,
+    }),
+    ApiResponse({
+      status: 201,
+      description: '질문 생성 성공',
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청',
+    }),
+  );
+}
+
+export function GetQuestionsCountSwagger() {
+  return applyDecorators(
+    ApiExtraModels(QuestionCountDto),
+    ApiOperation({
+      summary: '전체 질문 수 조회',
+      description: '전체 질문의 수를 답변 갯수와 채택 여부를 기준으로 조회합니다.',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '질문 상세 갯수 조회 성공',
+      type: QuestionCountDto,
+    }),
+    ApiResponse({
+      status: 404,
+      description: '질문 갯수를 조회할 수 없음',
+    }),
+  );
+}
+
+export function GetQuestionsSwagger() {
+  return applyDecorators(
+    ApiExtraModels(QuestionCursorResponseDto),
+    ApiOperation({
+      summary: '질문 목록 조회',
+      description:
+        '질문 목록을 조회합니다. 상태, 정렬 기준으로 필터링하고 페이지네이션할 수 있습니다.',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '질문 목록 조회 성공',
+      type: QuestionCursorResponseDto,
+    }),
+  );
+}
+
+export function GetQuestionSwagger() {
+  return applyDecorators(
+    ApiExtraModels(QuestionDetailItemDto),
+    ApiOperation({
+      summary: '질문 상세 조회',
+      description: '특정 질문의 상세 정보를 조회합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '질문 ID',
+      example: '1',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '질문 상세 조회 성공',
+      type: QuestionDetailItemDto,
+    }),
+    ApiResponse({
+      status: 404,
+      description: '질문을 찾을 수 없음',
+    }),
+  );
+}
+
+export function UpdateQuestionSwagger() {
+  return applyDecorators(
+    ApiExtraModels(UpdateQuestionDto, QuestionResponseDto),
+    ApiOperation({
+      summary: '질문 수정',
+      description: '기존 질문을 수정합니다.',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '질문 수정 성공',
+      type: QuestionResponseDto,
+    }),
+    ApiResponse({
+      status: 404,
+      description: '질문 찾기 실패',
+    }),
+  );
+}
+
+export function DeleteQuestionSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '질문 삭제',
+      description: '기존 질문을 삭제합니다.',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '질문 삭제 성공',
+    }),
+    ApiResponse({
+      status: 404,
+      description: '질문을 찾을 수 없음',
+    }),
+  );
+}
+
+export function AcceptAnswerSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '답변 채택',
+      description: '질문에 달린 답변을 채택합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '질문 ID',
+      example: '1',
+    }),
+    ApiParam({
+      name: 'answerId',
+      description: '답변 ID',
+      example: '1',
+    }),
+    ApiResponse({ status: 200, description: '답변 채택 성공' }),
+    ApiResponse({ status: 404, description: '질문 또는 답변을 찾을 수 없음' }),
+  );
+}
+
+export function LikeQuestionSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '질문 좋아요',
+      description: '질문에 좋아요를 누릅니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '질문 ID',
+      example: '1',
+    }),
+    ApiResponse({ status: 200, description: '질문 좋아요 성공' }),
+    ApiResponse({ status: 404, description: '질문을 찾을 수 없음' }),
+  );
+}
+
+export function DislikeQuestionSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '질문 싫어요',
+      description: '질문에 싫어요를 누릅니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '질문 ID',
+      example: '1',
+    }),
+    ApiResponse({ status: 200, description: '질문 싫어요 성공' }),
+    ApiResponse({ status: 404, description: '질문을 찾을 수 없음' }),
+  );
+}

--- a/BE/src/config/swagger/question-swagger.decorator.ts
+++ b/BE/src/config/swagger/question-swagger.decorator.ts
@@ -99,6 +99,11 @@ export function UpdateQuestionSwagger() {
       description: '질문 수정 성공',
       type: QuestionResponseDto,
     }),
+    ApiParam({
+      name: 'id',
+      description: '질문 ID',
+      example: '1',
+    }),
     ApiResponse({
       status: 404,
       description: '질문 찾기 실패',
@@ -111,6 +116,11 @@ export function DeleteQuestionSwagger() {
     ApiOperation({
       summary: '질문 삭제',
       description: '기존 질문을 삭제합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '질문 ID',
+      example: '1',
     }),
     ApiResponse({
       status: 200,

--- a/BE/src/config/swagger/story-swagger.decorator.ts
+++ b/BE/src/config/swagger/story-swagger.decorator.ts
@@ -1,0 +1,211 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiExtraModels, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import {
+  CreateStoryRequestDto,
+  CreateStoryResponseDto,
+  StoryListResponseDto,
+  StoryResponseDto,
+} from 'src/story/dto';
+
+export function GetStoriesSwagger() {
+  return applyDecorators(
+    ApiExtraModels(StoryListResponseDto),
+    ApiOperation({
+      summary: '스토리 목록 조회',
+      description: '발행된 스토리 목록을 조회합니다. 정렬 기준과 집계 기간을 선택할 수 있습니다.',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '스토리 목록 조회 성공',
+      type: StoryListResponseDto,
+    }),
+  );
+}
+
+export function GetStorySwagger() {
+  return applyDecorators(
+    ApiExtraModels(StoryResponseDto),
+    ApiOperation({
+      summary: '스토리 상세 조회',
+      description:
+        '특정 스토리의 상세 정보를 조회합니다. 조회수 증가는 POST /stories/:id/view 를 사용하세요.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '스토리 ID',
+      example: '1',
+      type: 'string',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '스토리 상세 조회 성공',
+      type: StoryResponseDto,
+    }),
+    ApiResponse({
+      status: 404,
+      description: '스토리를 찾을 수 없음',
+    }),
+  );
+}
+
+export function IncrementStoryViewSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '스토리 조회수 증가',
+      description:
+        '특정 스토리의 조회수를 1 증가시킵니다. bid 쿠키 기반으로 동일 뷰어의 중복 증가를 방지합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '스토리 ID',
+      example: '1',
+      type: 'string',
+    }),
+    ApiResponse({
+      status: 201,
+      description: '조회수 증가 처리 완료',
+    }),
+    ApiResponse({
+      status: 404,
+      description: '스토리를 찾을 수 없음',
+    }),
+  );
+}
+
+export function CreateStorySwagger() {
+  return applyDecorators(
+    ApiExtraModels(CreateStoryRequestDto, CreateStoryResponseDto),
+    ApiOperation({
+      summary: '스토리 생성',
+      description: '새로운 스토리를 생성합니다. (크롤러 전용)',
+    }),
+    ApiBody({
+      type: CreateStoryRequestDto,
+    }),
+    ApiResponse({
+      status: 201,
+      description: '스토리 생성 성공',
+      type: CreateStoryResponseDto,
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청',
+    }),
+  );
+}
+
+export function LikeStorySwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '캠퍼들의 이야기 좋아요 등록',
+      description: '로그인한 사용자가 캠퍼들의 이야기에 좋아요를 등록합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '스토리 ID',
+      example: '1',
+      type: 'string',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '좋아요 등록 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          storyId: {
+            type: 'string',
+            example: '1',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: '인증 실패',
+    }),
+    ApiResponse({
+      status: 404,
+      description: '스토리를 찾을 수 없음',
+    }),
+    ApiResponse({
+      status: 409,
+      description: '이미 좋아요한 상태',
+    }),
+  );
+}
+
+export function UnlikeStorySwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '캠퍼들의 이야기 좋아요 취소',
+      description: '로그인한 사용자가 캠퍼들의 이야기 좋아요를 취소합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '스토리 ID',
+      example: '1',
+      type: 'string',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '좋아요 취소 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          storyId: {
+            type: 'string',
+            example: '1',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: '인증 실패',
+    }),
+    ApiResponse({
+      status: 404,
+      description: '스토리를 찾을 수 없음',
+    }),
+    ApiResponse({
+      status: 400,
+      description: '좋아요하지 않은 상태',
+    }),
+  );
+}
+
+export function CheckStoryLikeStatusSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '캠퍼들의 이야기 좋아요 상태 확인',
+      description: '로그인한 사용자가 특정 스토리에 좋아요를 눌렀는지 확인합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '스토리 ID',
+      example: '1',
+      type: 'string',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '좋아요 상태 확인 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          isLiked: {
+            type: 'boolean',
+            example: true,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: '인증 실패',
+    }),
+    ApiResponse({
+      status: 404,
+      description: '스토리를 찾을 수 없음',
+    }),
+  );
+}

--- a/BE/src/project/project.module.ts
+++ b/BE/src/project/project.module.ts
@@ -1,17 +1,17 @@
 import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaModule } from 'src/prisma/prisma.module';
+import { ViewModule } from 'src/view/view.module';
+import { AuthRepository } from 'src/auth/auth.repository';
 import { ProjectController } from './project.controller';
 import { ProjectService } from './project.service';
-import { ViewService } from 'src/view/view.service';
-import { JwtService } from '@nestjs/jwt';
 import { ProjectRepository } from './project.repository';
-import { AuthRepository } from 'src/auth/auth.repository';
-import { PrismaModule } from 'src/prisma/prisma.module';
 import { RedisModule } from 'src/redis/redis.module';
-import { HttpModule } from '@nestjs/axios';
 
 @Module({
-  imports: [PrismaModule, RedisModule, HttpModule],
+  imports: [PrismaModule, ViewModule, HttpModule, RedisModule],
   controllers: [ProjectController],
-  providers: [ProjectService, ViewService, ProjectRepository, AuthRepository, JwtService],
+  providers: [ProjectService, ProjectRepository, AuthRepository, JwtService],
 })
-export class ProjectModule {}
+export class ProjectModule { }

--- a/BE/src/project/project.module.ts
+++ b/BE/src/project/project.module.ts
@@ -14,4 +14,4 @@ import { RedisModule } from 'src/redis/redis.module';
   controllers: [ProjectController],
   providers: [ProjectService, ProjectRepository, AuthRepository, JwtService],
 })
-export class ProjectModule { }
+export class ProjectModule {}

--- a/BE/src/project/project.service.ts
+++ b/BE/src/project/project.service.ts
@@ -470,11 +470,12 @@ export class ProjectService {
   async findOneWithViewCount(id: number, viewerKey: string) {
     const projectId = BigInt(id);
 
-    void this.viewService.shouldIncrementView('project', id, viewerKey)
-      .then(firstView => {
+    void this.viewService
+      .shouldIncrementView('project', id, viewerKey)
+      .then((firstView) => {
         if (firstView) return this.viewService.incrementViewCount('project', projectId);
       })
-      .catch(err => this.logger.error('[ViewCount] project 처리 실패', err));
+      .catch((err) => this.logger.error('[ViewCount] project 처리 실패', err));
 
     const project = await this.projectRepository.findById(projectId);
     return plainToInstance(ProjectDetailItemDto, project, { excludeExtraneousValues: true });

--- a/BE/src/project/project.service.ts
+++ b/BE/src/project/project.service.ts
@@ -472,8 +472,7 @@ export class ProjectService {
     const firstView = await this.viewService.shouldIncrementView('project', id, viewerKey);
 
     if (firstView) {
-      const project = await this.projectRepository.incrementViewCountAndFind(projectId);
-      return plainToInstance(ProjectDetailItemDto, project, { excludeExtraneousValues: true });
+      await this.viewService.incrementViewCount('project', projectId);
     }
 
     const project = await this.projectRepository.findById(projectId);

--- a/BE/src/project/project.service.ts
+++ b/BE/src/project/project.service.ts
@@ -470,6 +470,11 @@ export class ProjectService {
   async findOneWithViewCount(id: number, viewerKey: string) {
     const projectId = BigInt(id);
 
+    const project = await this.projectRepository.findById(projectId);
+    if (!project) {
+      throw new ProjectNotFoundException(id);
+    }
+
     void this.viewService
       .shouldIncrementView('project', id, viewerKey)
       .then((firstView) => {
@@ -477,7 +482,6 @@ export class ProjectService {
       })
       .catch((err) => this.logger.error('[ViewCount] project 처리 실패', err));
 
-    const project = await this.projectRepository.findById(projectId);
     return plainToInstance(ProjectDetailItemDto, project, { excludeExtraneousValues: true });
   }
 

--- a/BE/src/project/project.service.ts
+++ b/BE/src/project/project.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 import { Prisma } from '../generated/prisma/client';
 import { CreateProjectDto } from './dto/create-project.dto';
@@ -36,6 +36,7 @@ import { firstValueFrom } from 'rxjs';
 
 @Injectable()
 export class ProjectService {
+  private readonly logger = new Logger(ProjectService.name);
   private readonly s3: S3Client;
   private readonly endpoint: string;
   private readonly bucket: string;
@@ -469,11 +470,11 @@ export class ProjectService {
   async findOneWithViewCount(id: number, viewerKey: string) {
     const projectId = BigInt(id);
 
-    const firstView = await this.viewService.shouldIncrementView('project', id, viewerKey);
-
-    if (firstView) {
-      await this.viewService.incrementViewCount('project', projectId);
-    }
+    void this.viewService.shouldIncrementView('project', id, viewerKey)
+      .then(firstView => {
+        if (firstView) return this.viewService.incrementViewCount('project', projectId);
+      })
+      .catch(err => this.logger.error('[ViewCount] project 처리 실패', err));
 
     const project = await this.projectRepository.findById(projectId);
     return plainToInstance(ProjectDetailItemDto, project, { excludeExtraneousValues: true });

--- a/BE/src/question/question.controller.ts
+++ b/BE/src/question/question.controller.ts
@@ -38,7 +38,7 @@ import {
 @ApiTags('질문')
 @Controller('questions')
 export class QuestionController {
-  constructor(private readonly questionService: QuestionService) {}
+  constructor(private readonly questionService: QuestionService) { }
 
   @Post()
   @CreateQuestionSwagger()
@@ -72,11 +72,11 @@ export class QuestionController {
   @Public()
   @Post(':id/view')
   @UseGuards(ViewerKeyGuard)
-  async incrementStoryView(
+  async incrementQuestionView(
     @Param('id', ParseBigIntPipe) id: bigint,
     @ViewerKey() viewerKey: string,
   ): Promise<void> {
-    await this.questionService.incrementStoryView(id, viewerKey);
+    void this.questionService.incrementQuestionView(id, viewerKey);
   }
 
   @Patch(':id')

--- a/BE/src/question/question.controller.ts
+++ b/BE/src/question/question.controller.ts
@@ -13,7 +13,6 @@ import { ApiTags } from '@nestjs/swagger';
 import { Public } from '../auth/decorator/public.decorator';
 import { CreateQuestionDto } from './dto/req/create-question.dto';
 import { QuestionQueryDto } from './dto/req/question-query.dto';
-import { QuestionResponseDto } from './dto/res/detail/question-response.dto';
 import { QuestionService } from './question.service';
 import { responseMessage } from '../common/decorator/response-message.decorator';
 import { UpdateQuestionDto } from './dto/req/update-question.dto';
@@ -21,8 +20,6 @@ import { CurrentMember } from 'src/auth/decorator/current-member.decorator';
 import { ViewerKeyGuard } from 'src/view/guard/view.guard';
 import { ViewerKey } from 'src/view/decorator/viewer-key.decorator';
 import { ParseBigIntPipe } from 'src/common/pipe/parse-bigint.pipe';
-import { QuestionCursorResponseDto } from './dto/res/all/question-list.dto';
-import { QuestionDetailItemDto } from './dto/res/detail/question-detail-item.dto';
 import {
   AcceptAnswerSwagger,
   CreateQuestionSwagger,
@@ -38,7 +35,7 @@ import {
 @ApiTags('질문')
 @Controller('questions')
 export class QuestionController {
-  constructor(private readonly questionService: QuestionService) { }
+  constructor(private readonly questionService: QuestionService) {}
 
   @Post()
   @CreateQuestionSwagger()
@@ -72,10 +69,10 @@ export class QuestionController {
   @Public()
   @Post(':id/view')
   @UseGuards(ViewerKeyGuard)
-  async incrementQuestionView(
+  incrementQuestionView(
     @Param('id', ParseBigIntPipe) id: bigint,
     @ViewerKey() viewerKey: string,
-  ): Promise<void> {
+  ): void {
     void this.questionService.incrementQuestionView(id, viewerKey);
   }
 

--- a/BE/src/question/question.controller.ts
+++ b/BE/src/question/question.controller.ts
@@ -9,13 +9,12 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { Public } from '../auth/decorator/public.decorator';
 import { CreateQuestionDto } from './dto/req/create-question.dto';
 import { QuestionQueryDto } from './dto/req/question-query.dto';
 import { QuestionResponseDto } from './dto/res/detail/question-response.dto';
 import { QuestionService } from './question.service';
-import { QuestionCountDto } from './dto/res/question-count.dto';
 import { responseMessage } from '../common/decorator/response-message.decorator';
 import { UpdateQuestionDto } from './dto/req/update-question.dto';
 import { CurrentMember } from 'src/auth/decorator/current-member.decorator';
@@ -24,6 +23,17 @@ import { ViewerKey } from 'src/view/decorator/viewer-key.decorator';
 import { ParseBigIntPipe } from 'src/common/pipe/parse-bigint.pipe';
 import { QuestionCursorResponseDto } from './dto/res/all/question-list.dto';
 import { QuestionDetailItemDto } from './dto/res/detail/question-detail-item.dto';
+import {
+  AcceptAnswerSwagger,
+  CreateQuestionSwagger,
+  DeleteQuestionSwagger,
+  DislikeQuestionSwagger,
+  GetQuestionSwagger,
+  GetQuestionsCountSwagger,
+  GetQuestionsSwagger,
+  LikeQuestionSwagger,
+  UpdateQuestionSwagger,
+} from 'src/config/swagger/question-swagger.decorator';
 
 @ApiTags('질문')
 @Controller('questions')
@@ -31,40 +41,14 @@ export class QuestionController {
   constructor(private readonly questionService: QuestionService) {}
 
   @Post()
-  @ApiOperation({
-    summary: '질문 생성',
-    description: '새로운 질문을 생성합니다.',
-  })
-  @ApiBody({
-    type: CreateQuestionDto,
-  })
-  @ApiResponse({
-    status: 201,
-    description: '질문 생성 성공',
-  })
-  @ApiResponse({
-    status: 400,
-    description: '잘못된 요청',
-  })
+  @CreateQuestionSwagger()
   create(@Body() createQuestionDto: CreateQuestionDto, @CurrentMember() memberId: string) {
     return this.questionService.create(memberId, createQuestionDto);
   }
 
   @Public()
   @Get('count')
-  @ApiOperation({
-    summary: '전체 질문 수 조회',
-    description: '전체 질문의 수를 답변 갯수와 채택 여부를 기준으로 조회합니다.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '질문 상세 갯수 조회 성공',
-    type: QuestionCountDto,
-  })
-  @ApiResponse({
-    status: 404,
-    description: '질문 갯수를 조회할 수 없음',
-  })
+  @GetQuestionsCountSwagger()
   getQuestionsCount() {
     return this.questionService.getQuestionsCount();
   }
@@ -72,16 +56,7 @@ export class QuestionController {
   @Public()
   @Get()
   @responseMessage('질문 목록 조회')
-  @ApiOperation({
-    summary: '질문 목록 조회',
-    description:
-      '질문 목록을 조회합니다. 상태, 정렬 기준으로 필터링하고 페이지네이션할 수 있습니다.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '질문 목록 조회 성공',
-    type: QuestionCursorResponseDto,
-  })
+  @GetQuestionsSwagger()
   findAll(@Query() query: QuestionQueryDto, @CurrentMember() memberId?: string) {
     return this.questionService.findAllCursor(query, memberId);
   }
@@ -89,24 +64,7 @@ export class QuestionController {
   @Public()
   @Get(':id')
   @responseMessage('질문 상세 조회 성공!')
-  @ApiOperation({
-    summary: '질문 상세 조회',
-    description: '특정 질문의 상세 정보를 조회합니다.',
-  })
-  @ApiParam({
-    name: 'id',
-    description: '질문 ID',
-    example: '1',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '질문 상세 조회 성공',
-    type: QuestionDetailItemDto,
-  })
-  @ApiResponse({
-    status: 404,
-    description: '질문을 찾을 수 없음',
-  })
+  @GetQuestionSwagger()
   async findOne(@Param('id') id: string, @CurrentMember() memberId?: string) {
     return await this.questionService.findOne(id, memberId);
   }
@@ -123,19 +81,7 @@ export class QuestionController {
 
   @Patch(':id')
   @responseMessage('질문 수정 성공')
-  @ApiOperation({
-    summary: '질문 수정',
-    description: '기존 질문을 수정합니다.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '질문 수정 성공',
-    type: QuestionResponseDto,
-  })
-  @ApiResponse({
-    status: 404,
-    description: '질문 찾기 실패',
-  })
+  @UpdateQuestionSwagger()
   update(
     @Param('id') id: string,
     @CurrentMember() memberId: string,
@@ -146,30 +92,14 @@ export class QuestionController {
 
   @Delete(':id')
   @responseMessage('질문 삭제 성공')
-  @ApiOperation({
-    summary: '질문 삭제',
-    description: '기존 질문을 삭제합니다.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '질문 삭제 성공',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '질문을 찾을 수 없음',
-  })
+  @DeleteQuestionSwagger()
   remove(@Param('id') id: string, @CurrentMember() memberId: string) {
     return this.questionService.delete(id, memberId);
   }
 
   @Post(':id/answers/:answerId/accept')
   @responseMessage('답변 채택 성공')
-  @ApiOperation({
-    summary: '답변 채택',
-    description: '질문에 달린 답변을 채택합니다.',
-  })
-  @ApiResponse({ status: 200, description: '답변 채택 성공' })
-  @ApiResponse({ status: 404, description: '질문 또는 답변을 찾을 수 없음' })
+  @AcceptAnswerSwagger()
   accept(
     @Param('id') questionId: string,
     @Param('answerId') answerId: string,
@@ -180,24 +110,14 @@ export class QuestionController {
 
   @Post(':id/like')
   @responseMessage('질문 좋아요 성공')
-  @ApiOperation({
-    summary: '질문 좋아요',
-    description: '질문에 좋아요를 누릅니다.',
-  })
-  @ApiResponse({ status: 200, description: '질문 좋아요 성공' })
-  @ApiResponse({ status: 404, description: '질문을 찾을 수 없음' })
+  @LikeQuestionSwagger()
   async like(@Param('id') questionId: string, @CurrentMember() memberId: string) {
     return { questionId: await this.questionService.like(questionId, memberId) };
   }
 
   @Post(':id/dislike')
   @responseMessage('질문 싫어요 성공')
-  @ApiOperation({
-    summary: '질문 싫어요',
-    description: '질문에 싫어요를 누릅니다.',
-  })
-  @ApiResponse({ status: 200, description: '질문 싫어요 성공' })
-  @ApiResponse({ status: 404, description: '질문을 찾을 수 없음' })
+  @DislikeQuestionSwagger()
   async dislike(@Param('id') questionId: string, @CurrentMember() memberId: string) {
     return { questionId: await this.questionService.dislike(questionId, memberId) };
   }

--- a/BE/src/question/question.module.ts
+++ b/BE/src/question/question.module.ts
@@ -1,14 +1,13 @@
 import { Module } from '@nestjs/common';
+import { ViewModule } from 'src/view/view.module';
+import { AuthRepository } from 'src/auth/auth.repository';
 import { QuestionService } from './question.service';
 import { QuestionController } from './question.controller';
 import { QuestionRepository } from './question.repository';
-import { RedisModule } from 'src/redis/redis.module';
-import { ViewService } from 'src/view/view.service';
-import { AuthRepository } from 'src/auth/auth.repository';
 
 @Module({
-  imports: [RedisModule],
+  imports: [ViewModule],
   controllers: [QuestionController],
-  providers: [QuestionService, ViewService, QuestionRepository, AuthRepository],
+  providers: [QuestionService, QuestionRepository, AuthRepository],
 })
 export class QuestionModule {}

--- a/BE/src/question/question.service.ts
+++ b/BE/src/question/question.service.ts
@@ -270,7 +270,7 @@ export class QuestionService {
       viewerKey,
     );
     if (shouldIncrement) {
-      await this.questionRepo.incrementViewCount(id);
+      await this.viewService.incrementViewCount('question', id);
     }
   }
 

--- a/BE/src/question/question.service.ts
+++ b/BE/src/question/question.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   ForbiddenException,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { Prisma } from 'src/generated/prisma/client';
@@ -24,11 +25,13 @@ const toHashtagsStringOrNull = (hashtags?: string[]): string | null =>
 
 @Injectable()
 export class QuestionService {
+  private readonly logger = new Logger(QuestionService.name);
+
   constructor(
     private readonly questionRepo: QuestionRepository,
     private readonly viewService: ViewService,
     private readonly authRepository: AuthRepository,
-  ) {}
+  ) { }
   //응답 dto 없음
   async create(memberIdStr: string, dto: CreateQuestionDto) {
     const memberId = BigInt(memberIdStr);
@@ -256,21 +259,23 @@ export class QuestionService {
     };
   }
 
-  async incrementStoryView(id: bigint, viewerKey: string): Promise<void> {
-    const questionId = BigInt(id);
+  async incrementQuestionView(id: bigint, viewerKey: string): Promise<void> {
+    try {
+      const questionId = BigInt(id);
 
-    const questionExists = await this.questionRepo.checkQuestionExists(questionId);
-    if (!questionExists) {
-      throw new QuestionNotFoundException(questionId);
-    }
+      const questionExists = await this.questionRepo.checkQuestionExists(questionId);
+      if (!questionExists) return;
 
-    const shouldIncrement = await this.viewService.shouldIncrementView(
-      'question',
-      questionId,
-      viewerKey,
-    );
-    if (shouldIncrement) {
-      await this.viewService.incrementViewCount('question', id);
+      const shouldIncrement = await this.viewService.shouldIncrementView(
+        'question',
+        questionId,
+        viewerKey,
+      );
+      if (shouldIncrement) {
+        await this.viewService.incrementViewCount('question', id);
+      }
+    } catch (error) {
+      this.logger.error(error);
     }
   }
 

--- a/BE/src/question/question.service.ts
+++ b/BE/src/question/question.service.ts
@@ -31,7 +31,7 @@ export class QuestionService {
     private readonly questionRepo: QuestionRepository,
     private readonly viewService: ViewService,
     private readonly authRepository: AuthRepository,
-  ) { }
+  ) {}
   //응답 dto 없음
   async create(memberIdStr: string, dto: CreateQuestionDto) {
     const memberId = BigInt(memberIdStr);

--- a/BE/src/story/story.controller.ts
+++ b/BE/src/story/story.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Delete, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { CurrentMember } from '../auth/decorator/current-member.decorator';
 import { Public } from '../auth/decorator/public.decorator';
 import { ParseBigIntPipe } from '../common/pipe/parse-bigint.pipe';
@@ -13,49 +13,31 @@ import {
   StoryResponseDto,
 } from './dto';
 import { StoryService } from './story.service';
+import {
+  CheckStoryLikeStatusSwagger,
+  CreateStorySwagger,
+  GetStoriesSwagger,
+  GetStorySwagger,
+  IncrementStoryViewSwagger,
+  LikeStorySwagger,
+  UnlikeStorySwagger,
+} from 'src/config/swagger/story-swagger.decorator';
 
 @ApiTags('캠퍼들의 이야기')
 @Controller('stories')
 export class StoryController {
-  constructor(private readonly storyService: StoryService) {}
+  constructor(private readonly storyService: StoryService) { }
 
   @Public()
   @Get()
-  @ApiOperation({
-    summary: '스토리 목록 조회',
-    description: '발행된 스토리 목록을 조회합니다. 정렬 기준과 집계 기간을 선택할 수 있습니다.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '스토리 목록 조회 성공',
-    type: StoryListResponseDto,
-  })
+  @GetStoriesSwagger()
   async getStories(@Query() query: StoryListRequestDto): Promise<StoryListResponseDto> {
     return await this.storyService.findAllPublishedStories(query);
   }
 
   @Public()
   @Get(':id')
-  @ApiOperation({
-    summary: '스토리 상세 조회',
-    description:
-      '특정 스토리의 상세 정보를 조회합니다. 조회수 증가는 POST /stories/:id/view 를 사용하세요.',
-  })
-  @ApiParam({
-    name: 'id',
-    description: '스토리 ID',
-    example: '1',
-    type: 'string',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '스토리 상세 조회 성공',
-    type: StoryResponseDto,
-  })
-  @ApiResponse({
-    status: 404,
-    description: '스토리를 찾을 수 없음',
-  })
+  @GetStorySwagger()
   async getStory(@Param('id', ParseBigIntPipe) id: bigint): Promise<StoryResponseDto> {
     return await this.storyService.findStoryById(id);
   }
@@ -63,25 +45,7 @@ export class StoryController {
   @Public()
   @Post(':id/view')
   @UseGuards(ViewerKeyGuard)
-  @ApiOperation({
-    summary: '스토리 조회수 증가',
-    description:
-      '특정 스토리의 조회수를 1 증가시킵니다. bid 쿠키 기반으로 동일 뷰어의 중복 증가를 방지합니다.',
-  })
-  @ApiParam({
-    name: 'id',
-    description: '스토리 ID',
-    example: '1',
-    type: 'string',
-  })
-  @ApiResponse({
-    status: 201,
-    description: '조회수 증가 처리 완료',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '스토리를 찾을 수 없음',
-  })
+  @IncrementStoryViewSwagger()
   async incrementStoryView(
     @Param('id', ParseBigIntPipe) id: bigint,
     @ViewerKey() viewerKey: string,
@@ -91,46 +55,13 @@ export class StoryController {
 
   @Public()
   @Post()
+  @CreateStorySwagger()
   async createStory(@Body() dto: CreateStoryRequestDto): Promise<CreateStoryResponseDto> {
     return await this.storyService.createStory(dto);
   }
 
   @Post(':id/like')
-  @ApiOperation({
-    summary: '캠퍼들의 이야기 좋아요 등록',
-    description: '로그인한 사용자가 캠퍼들의 이야기에 좋아요를 등록합니다.',
-  })
-  @ApiParam({
-    name: 'id',
-    description: '스토리 ID',
-    example: '1',
-    type: 'string',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '좋아요 등록 성공',
-    schema: {
-      type: 'object',
-      properties: {
-        storyId: {
-          type: 'string',
-          example: '1',
-        },
-      },
-    },
-  })
-  @ApiResponse({
-    status: 401,
-    description: '인증 실패',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '스토리를 찾을 수 없음',
-  })
-  @ApiResponse({
-    status: 409,
-    description: '이미 좋아요한 상태',
-  })
+  @LikeStorySwagger()
   async likeStory(
     @Param('id', ParseBigIntPipe) id: bigint,
     @CurrentMember() memberId: bigint,
@@ -140,41 +71,7 @@ export class StoryController {
   }
 
   @Delete(':id/like')
-  @ApiOperation({
-    summary: '캠퍼들의 이야기 좋아요 취소',
-    description: '로그인한 사용자가 캠퍼들의 이야기 좋아요를 취소합니다.',
-  })
-  @ApiParam({
-    name: 'id',
-    description: '스토리 ID',
-    example: '1',
-    type: 'string',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '좋아요 취소 성공',
-    schema: {
-      type: 'object',
-      properties: {
-        storyId: {
-          type: 'string',
-          example: '1',
-        },
-      },
-    },
-  })
-  @ApiResponse({
-    status: 401,
-    description: '인증 실패',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '스토리를 찾을 수 없음',
-  })
-  @ApiResponse({
-    status: 400,
-    description: '좋아요하지 않은 상태',
-  })
+  @UnlikeStorySwagger()
   async unlikeStory(
     @Param('id', ParseBigIntPipe) id: bigint,
     @CurrentMember() memberId: bigint,
@@ -184,37 +81,7 @@ export class StoryController {
   }
 
   @Get(':id/like/status')
-  @ApiOperation({
-    summary: '캠퍼들의 이야기 좋아요 상태 확인',
-    description: '로그인한 사용자가 특정 스토리에 좋아요를 눌렀는지 확인합니다.',
-  })
-  @ApiParam({
-    name: 'id',
-    description: '스토리 ID',
-    example: '1',
-    type: 'string',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '좋아요 상태 확인 성공',
-    schema: {
-      type: 'object',
-      properties: {
-        isLiked: {
-          type: 'boolean',
-          example: true,
-        },
-      },
-    },
-  })
-  @ApiResponse({
-    status: 401,
-    description: '인증 실패',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '스토리를 찾을 수 없음',
-  })
+  @CheckStoryLikeStatusSwagger()
   async checkStoryLikeStatus(
     @Param('id', ParseBigIntPipe) id: bigint,
     @CurrentMember() memberId: bigint,

--- a/BE/src/story/story.controller.ts
+++ b/BE/src/story/story.controller.ts
@@ -46,11 +46,12 @@ export class StoryController {
   @Post(':id/view')
   @UseGuards(ViewerKeyGuard)
   @IncrementStoryViewSwagger()
-  incrementStoryView(
+  async incrementStoryView(
     @Param('id', ParseBigIntPipe) id: bigint,
     @ViewerKey() viewerKey: string,
-  ): void {
-    void this.storyService.incrementStoryView(id, viewerKey);
+  ): Promise<void> {
+    await this.storyService.incrementStoryView(id, viewerKey);
+    return;
   }
 
   @Public()

--- a/BE/src/story/story.controller.ts
+++ b/BE/src/story/story.controller.ts
@@ -50,7 +50,7 @@ export class StoryController {
     @Param('id', ParseBigIntPipe) id: bigint,
     @ViewerKey() viewerKey: string,
   ): Promise<void> {
-    await this.storyService.incrementStoryView(id, viewerKey);
+    void this.storyService.incrementStoryView(id, viewerKey);
   }
 
   @Public()

--- a/BE/src/story/story.controller.ts
+++ b/BE/src/story/story.controller.ts
@@ -26,7 +26,7 @@ import {
 @ApiTags('캠퍼들의 이야기')
 @Controller('stories')
 export class StoryController {
-  constructor(private readonly storyService: StoryService) { }
+  constructor(private readonly storyService: StoryService) {}
 
   @Public()
   @Get()
@@ -46,10 +46,10 @@ export class StoryController {
   @Post(':id/view')
   @UseGuards(ViewerKeyGuard)
   @IncrementStoryViewSwagger()
-  async incrementStoryView(
+  incrementStoryView(
     @Param('id', ParseBigIntPipe) id: bigint,
     @ViewerKey() viewerKey: string,
-  ): Promise<void> {
+  ): void {
     void this.storyService.incrementStoryView(id, viewerKey);
   }
 

--- a/BE/src/story/story.module.ts
+++ b/BE/src/story/story.module.ts
@@ -1,15 +1,14 @@
 import { Module } from '@nestjs/common';
 import { FeedModule } from '../feed/feed.module';
 import { PrismaModule } from '../prisma/prisma.module';
-import { RedisModule } from '../redis/redis.module';
-import { ViewService } from '../view/view.service';
+import { ViewModule } from '../view/view.module';
 import { StoryController } from './story.controller';
 import { StoryRepository } from './story.repository';
 import { StoryService } from './story.service';
 
 @Module({
-  imports: [PrismaModule, FeedModule, RedisModule],
+  imports: [PrismaModule, FeedModule, ViewModule],
   controllers: [StoryController],
-  providers: [StoryService, StoryRepository, ViewService],
+  providers: [StoryService, StoryRepository],
 })
 export class StoryModule {}

--- a/BE/src/story/story.service.ts
+++ b/BE/src/story/story.service.ts
@@ -30,7 +30,7 @@ export class StoryService {
     private readonly storyRepository: StoryRepository,
     private readonly feedRepository: FeedRepository,
     private readonly viewService: ViewService,
-  ) { }
+  ) {}
 
   /**
    * 모든 공개된 캠퍼들의 이야기 목록 조회

--- a/BE/src/story/story.service.ts
+++ b/BE/src/story/story.service.ts
@@ -27,7 +27,7 @@ export class StoryService {
     private readonly storyRepository: StoryRepository,
     private readonly feedRepository: FeedRepository,
     private readonly viewService: ViewService,
-  ) {}
+  ) { }
 
   /**
    * 모든 공개된 캠퍼들의 이야기 목록 조회
@@ -140,7 +140,7 @@ export class StoryService {
       60 * 60,
     );
     if (shouldIncrement) {
-      await this.storyRepository.incrementViewCount(id);
+      await this.viewService.incrementViewCount('story', id);
     }
   }
 

--- a/BE/src/story/story.service.ts
+++ b/BE/src/story/story.service.ts
@@ -20,9 +20,12 @@ import {
 } from './exception/story.exception';
 import { StoryRepository } from './story.repository';
 import { StorySortBy } from './type/story-query.type';
+import { Logger } from '@nestjs/common';
 
 @Injectable()
 export class StoryService {
+  private readonly logger = new Logger(StoryService.name);
+
   constructor(
     private readonly storyRepository: StoryRepository,
     private readonly feedRepository: FeedRepository,
@@ -128,19 +131,21 @@ export class StoryService {
    * @param viewerKey string (bid 쿠키 등)
    */
   async incrementStoryView(id: bigint, viewerKey: string): Promise<void> {
-    const storyExists = await this.storyRepository.checkStoryExists(id);
-    if (!storyExists) {
-      throw new StoryNotFoundException(id);
-    }
+    try {
+      const storyExists = await this.storyRepository.checkStoryExists(id);
+      if (!storyExists) return;
 
-    const shouldIncrement = await this.viewService.shouldIncrementView(
-      'story',
-      id,
-      viewerKey,
-      60 * 60,
-    );
-    if (shouldIncrement) {
-      await this.viewService.incrementViewCount('story', id);
+      const shouldIncrement = await this.viewService.shouldIncrementView(
+        'story',
+        id,
+        viewerKey,
+        60 * 60,
+      );
+      if (shouldIncrement) {
+        await this.viewService.incrementViewCount('story', id);
+      }
+    } catch (error) {
+      this.logger.error(error);
     }
   }
 

--- a/BE/src/story/story.service.ts
+++ b/BE/src/story/story.service.ts
@@ -131,22 +131,23 @@ export class StoryService {
    * @param viewerKey string (bid 쿠키 등)
    */
   async incrementStoryView(id: bigint, viewerKey: string): Promise<void> {
-    try {
-      const storyExists = await this.storyRepository.checkStoryExists(id);
-      if (!storyExists) return;
-
-      const shouldIncrement = await this.viewService.shouldIncrementView(
-        'story',
-        id,
-        viewerKey,
-        60 * 60,
-      );
-      if (shouldIncrement) {
-        await this.viewService.incrementViewCount('story', id);
-      }
-    } catch (error) {
-      this.logger.error(error);
+    const storyExists = await this.storyRepository.checkStoryExists(id);
+    if (!storyExists) {
+      throw new StoryNotFoundException(id);
     }
+
+    const shouldIncrement = await this.viewService.shouldIncrementView(
+      'story',
+      id,
+      viewerKey,
+      60 * 60,
+    );
+
+    if (!shouldIncrement) {
+      return;
+    }
+
+    this.viewService.incrementViewCount('story', id);
   }
 
   /**

--- a/BE/src/view/view-flush.service.ts
+++ b/BE/src/view/view-flush.service.ts
@@ -21,7 +21,7 @@ export class ViewFlushService {
   constructor(
     @Inject(REDIS) private readonly redis: Redis,
     private readonly prisma: PrismaService,
-  ) { }
+  ) {}
 
   @Interval(FLUSH_INTERVAL_MS)
   async flush(): Promise<void> {

--- a/BE/src/view/view-flush.service.ts
+++ b/BE/src/view/view-flush.service.ts
@@ -1,0 +1,115 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
+import type Redis from 'ioredis';
+import { REDIS } from '../redis/redis.provider';
+import { PrismaService } from '../prisma/prisma.service';
+
+const FLUSH_INTERVAL_MS = 5000;
+
+const RESOURCES = ['story', 'project', 'question'] as const;
+type Resource = (typeof RESOURCES)[number];
+
+interface ViewDelta {
+  id: bigint;
+  delta: number;
+}
+
+@Injectable()
+export class ViewFlushService {
+  private readonly logger = new Logger(ViewFlushService.name);
+
+  constructor(
+    @Inject(REDIS) private readonly redis: Redis,
+    private readonly prisma: PrismaService,
+  ) { }
+
+  @Interval(FLUSH_INTERVAL_MS)
+  async flush(): Promise<void> {
+    for (const resource of RESOURCES) {
+      await this.flushResource(resource);
+    }
+  }
+
+  private async flushResource(resource: Resource): Promise<void> {
+    const dirtyKey = `view:dirty:${resource}`;
+
+    const ids = await this.redis.smembers(dirtyKey);
+    if (ids.length === 0) return;
+
+    // pipeline으로 각 id의 카운터를 atomic하게 가져오면서 키 삭제
+    const pipeline = this.redis.pipeline();
+    for (const id of ids) {
+      pipeline.getdel(`view:count:${resource}:${id}`);
+    }
+    const results = await pipeline.exec();
+
+    const updates: ViewDelta[] = [];
+    if (results) {
+      for (let i = 0; i < ids.length; i++) {
+        /**
+         * result 구조:
+         * [null, '5'] → [에러없음, 이전값 '5']
+         * [null, null] → [에러없음, 이전값 없음]
+         */
+        const [err, raw] = results[i] as [Error | null, unknown];
+        if (err || raw === null || raw === undefined) continue;
+
+        const delta = parseInt(String(raw), 10);
+        if (delta > 0) {
+          updates.push({ id: BigInt(ids[i]), delta });
+        }
+      }
+    }
+
+    if (updates.length === 0) {
+      return;
+    }
+
+    try {
+      await this.batchUpdate(resource, updates);
+      await this.redis.srem(dirtyKey, ...ids);
+    } catch (err) {
+      this.logger.error(
+        `[ViewFlush] ${resource} batch update 실패, 다음 배치에서 재처리됩니다`,
+        err instanceof Error ? err.stack : String(err),
+      );
+    }
+  }
+
+  private async batchUpdate(resource: Resource, updates: ViewDelta[]): Promise<void> {
+    switch (resource) {
+      case 'story':
+        await this.prisma.$transaction(
+          updates.map(({ id, delta }) =>
+            this.prisma.story.update({
+              where: { id },
+              data: { viewCount: { increment: delta } },
+            }),
+          ),
+        );
+        break;
+      case 'project':
+        await this.prisma.$transaction(
+          updates.map(({ id, delta }) =>
+            this.prisma.project.update({
+              where: { id },
+              data: { viewCount: { increment: delta } },
+            }),
+          ),
+        );
+        break;
+      case 'question':
+        await this.prisma.$transaction(
+          updates.map(({ id, delta }) =>
+            this.prisma.question.update({
+              where: { id },
+              data: { viewCount: { increment: delta } },
+            }),
+          ),
+        );
+        break;
+    }
+
+    this.logger.log(`[ViewFlush] ${resource} ${updates.length}건 반영 완료`);
+  }
+}

--- a/BE/src/view/view-flush.service.ts
+++ b/BE/src/view/view-flush.service.ts
@@ -6,8 +6,8 @@ import { PrismaService } from '../prisma/prisma.service';
 
 const FLUSH_INTERVAL_MS = 5000;
 
-const RESOURCES = ['story', 'project', 'question'] as const;
-type Resource = (typeof RESOURCES)[number];
+export const RESOURCES = ['story', 'project', 'question'] as const;
+export type Resource = (typeof RESOURCES)[number];
 
 interface ViewDelta {
   id: bigint;
@@ -21,7 +21,7 @@ export class ViewFlushService {
   constructor(
     @Inject(REDIS) private readonly redis: Redis,
     private readonly prisma: PrismaService,
-  ) {}
+  ) { }
 
   @Interval(FLUSH_INTERVAL_MS)
   async flush(): Promise<void> {
@@ -39,7 +39,7 @@ export class ViewFlushService {
     // pipeline으로 각 id의 카운터를 atomic하게 가져오면서 키 삭제
     const pipeline = this.redis.pipeline();
     for (const id of ids) {
-      pipeline.getdel(`view:count:${resource}:${id}`);
+      pipeline.get(`view:count:${resource}:${id}`);
     }
     const results = await pipeline.exec();
 
@@ -68,11 +68,22 @@ export class ViewFlushService {
     }
 
     if (updates.length === 0) {
+      await this.redis.srem(dirtyKey, ...ids);
       return;
     }
 
     try {
+      // 먼저 DB 업데이트
       await this.batchUpdate(resource, updates);
+
+      // 카운터 키 삭제
+      const delPipeline = this.redis.pipeline();
+      for (const { id } of updates) {
+        delPipeline.del(`view:count:${resource}:${id}`);
+      }
+      await delPipeline.exec();
+
+      // dirty set 삭제
       await this.redis.srem(dirtyKey, ...ids);
     } catch (err) {
       this.logger.error(

--- a/BE/src/view/view-flush.service.ts
+++ b/BE/src/view/view-flush.service.ts
@@ -21,7 +21,7 @@ export class ViewFlushService {
   constructor(
     @Inject(REDIS) private readonly redis: Redis,
     private readonly prisma: PrismaService,
-  ) { }
+  ) {}
 
   @Interval(FLUSH_INTERVAL_MS)
   async flush(): Promise<void> {
@@ -54,7 +54,13 @@ export class ViewFlushService {
         const [err, raw] = results[i] as [Error | null, unknown];
         if (err || raw === null || raw === undefined) continue;
 
-        const delta = parseInt(String(raw), 10);
+        let rawStr: string;
+        if (typeof raw === 'string') rawStr = raw;
+        else if (typeof raw === 'number' || typeof raw === 'bigint') rawStr = raw.toString();
+        else if (Buffer.isBuffer(raw)) rawStr = raw.toString('utf8');
+        else continue;
+
+        const delta = parseInt(rawStr, 10);
         if (delta > 0) {
           updates.push({ id: BigInt(ids[i]), delta });
         }

--- a/BE/src/view/view.module.ts
+++ b/BE/src/view/view.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { RedisModule } from '../redis/redis.module';
+import { ViewFlushService } from './view-flush.service';
+import { ViewService } from './view.service';
+
+@Module({
+  imports: [RedisModule, PrismaModule],
+  providers: [ViewService, ViewFlushService],
+  exports: [ViewService],
+})
+export class ViewModule {}

--- a/BE/src/view/view.service.ts
+++ b/BE/src/view/view.service.ts
@@ -9,7 +9,7 @@ export interface ViewCountResult<T> {
 
 @Injectable()
 export class ViewService {
-  constructor(@Inject(REDIS) private readonly redis: Redis) { }
+  constructor(@Inject(REDIS) private readonly redis: Redis) {}
 
   /**
    * 조회수 증가 여부를 판단합니다.
@@ -84,10 +84,6 @@ export class ViewService {
     const countKey = `view:count:${resource}:${resourceId}`;
     const dirtyKey = `view:dirty:${resource}`;
 
-    await this.redis
-      .pipeline()
-      .incr(countKey)
-      .sadd(dirtyKey, String(resourceId))
-      .exec();
+    await this.redis.pipeline().incr(countKey).sadd(dirtyKey, String(resourceId)).exec();
   }
 }

--- a/BE/src/view/view.service.ts
+++ b/BE/src/view/view.service.ts
@@ -9,7 +9,7 @@ export interface ViewCountResult<T> {
 
 @Injectable()
 export class ViewService {
-  constructor(@Inject(REDIS) private readonly redis: Redis) {}
+  constructor(@Inject(REDIS) private readonly redis: Redis) { }
 
   /**
    * 조회수 증가 여부를 판단합니다.
@@ -73,5 +73,21 @@ export class ViewService {
     if (keys.length > 0) {
       await this.redis.del(...keys);
     }
+  }
+
+  /**
+   * Redis에 조회수 증가분을 누적합니다 (배치 flush용)
+   * @param resource 리소스 타입 (예: 'story', 'project', 'question')
+   * @param resourceId 리소스 ID
+   */
+  async incrementViewCount(resource: string, resourceId: number | bigint): Promise<void> {
+    const countKey = `view:count:${resource}:${resourceId}`;
+    const dirtyKey = `view:dirty:${resource}`;
+
+    await this.redis
+      .pipeline()
+      .incr(countKey)
+      .sadd(dirtyKey, String(resourceId))
+      .exec();
   }
 }

--- a/BE/src/view/view.service.ts
+++ b/BE/src/view/view.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import type Redis from 'ioredis';
 import { REDIS } from '../redis/redis.provider';
+import type { Resource } from './view-flush.service';
 
 export interface ViewCountResult<T> {
   data: T;
@@ -13,14 +14,14 @@ export class ViewService {
 
   /**
    * 조회수 증가 여부를 판단합니다.
-   * @param resource 리소스 타입 (예: 'project', 'story', 'qna')
+   * @param resource 리소스 타입 (`story` | `project` | `question`)
    * @param resourceId 리소스 ID
    * @param viewerKey 조회자 키
    * @param ttl TTL (초 단위, 기본 30분)
    * @returns 첫 조회 여부
    */
   async shouldIncrementView(
-    resource: string,
+    resource: Resource,
     resourceId: number | bigint,
     viewerKey: string,
     ttl: number = 60 * 30,
@@ -42,7 +43,7 @@ export class ViewService {
    * 여러 리소스의 조회 기록을 확인합니다.
    */
   async hasViewed(
-    resource: string,
+    resource: Resource,
     resourceId: number | bigint,
     viewerKey: string,
   ): Promise<boolean> {
@@ -55,7 +56,7 @@ export class ViewService {
    * 조회 기록을 삭제합니다 (관리자 기능 등에 활용)
    */
   async clearViewRecord(
-    resource: string,
+    resource: Resource,
     resourceId: number | bigint,
     viewerKey: string,
   ): Promise<void> {
@@ -66,7 +67,7 @@ export class ViewService {
   /**
    * 특정 리소스의 모든 조회 기록을 삭제합니다
    */
-  async clearAllViewRecords(resource: string, resourceId: number | bigint): Promise<void> {
+  async clearAllViewRecords(resource: Resource, resourceId: number | bigint): Promise<void> {
     const pattern = `view:${resource}:${resourceId}:*`;
     const keys = await this.redis.keys(pattern);
 
@@ -80,7 +81,7 @@ export class ViewService {
    * @param resource 리소스 타입 (예: 'story', 'project', 'question')
    * @param resourceId 리소스 ID
    */
-  async incrementViewCount(resource: string, resourceId: number | bigint): Promise<void> {
+  async incrementViewCount(resource: Resource, resourceId: number | bigint): Promise<void> {
     const countKey = `view:count:${resource}:${resourceId}`;
     const dirtyKey = `view:dirty:${resource}`;
 


### PR DESCRIPTION
## ⏳ 리뷰 예상 시간

약 30분

---

## 📝 기능 설명

조회수(View Count) 처리 방식을 **즉시 DB 반영** 방식에서 **Redis 카운터 누적 → 배치 Flush** 방식으로 전환합니다.

기존에는 조회 API 요청마다 DB에 직접 `UPDATE`를 수행했습니다. 이번 PR에서는 조회수 증가분을 Redis에 먼저 누적하고, 스케줄러(`@Interval`)가 5초마다 DB에 일괄 반영하도록 변경합니다.

이를 통해 **DB 부하를 줄이고**, **조회 API 응답 지연을 제거**합니다.

---

## 🛠 작업 사항

### 1. `ViewFlushService` 신규 생성 (`view-flush.service.ts`)

- `@Interval(5000)` 스케줄러로 5초마다 `flush()` 실행
- story, project, question 3가지 리소스에 대해 Redis의 `view:dirty:{resource}` set에서 dirty ID 목록을 가져옴
- pipeline + `GETDEL`로 각 ID의 누적 카운터를 atomic하게 읽고 삭제
- `prisma.$transaction`으로 변경된 ID들을 일괄 DB 업데이트
- DB 업데이트 성공 시에만 dirty set에서 ID 제거 (실패 시 다음 배치에서 재처리)

### 2. `ViewService`에 `incrementViewCount()` 추가 (`view.service.ts`)

- Redis pipeline으로 `view:count:{resource}:{id}` 카운터를 `INCR`하고 `view:dirty:{resource}` set에 id를 `SADD`
- 기존 `shouldIncrementView()`는 변경 없음

### 3. `ViewModule` 신규 생성 (`view.module.ts`)

- `ViewService` + `ViewFlushService`를 하나의 모듈로 관리
- `ViewService`를 export하여 story, project, question 모듈에서 사용

### 4. 조회수 처리 방식 리팩토링 (story, project, question)

- `storyService.incrementStoryView()`, `questionService.incrementQuestionView()`, `projectService.findOneWithViewCount()` 내부에서 직접 `repository.incrementViewCount()` 호출하던 부분을 `viewService.incrementViewCount()`로 교체
- 조회 API 컨트롤러/서비스에서 `void` + fire-and-forget 패턴 적용 (응답 지연 제거)
- 에러 발생 시 Logger로 기록하고 사용자에게 전파하지 않음

### 5. 모듈 의존성 정리

- `StoryModule`, `QuestionModule`, `ProjectModule`에서 `ViewService` 직접 provider 등록 제거
- 각 모듈이 `ViewModule`을 import하도록 통일

### 6. `@nestjs/schedule` 패키지 추가

- `ScheduleModule.forRoot()`를 `AppModule`에 등록

### 7. ESLint 규칙 완화 (`eslint.config.mjs`)

- export function에 `PascalCase` 허용 (NestJS 커스텀 데코레이터 팩토리 함수 컨벤션 지원)
- `project-swagger.decorator.ts`의 `eslint-disable` 주석 제거

### 8. 로드 테스트 스크립트 추가 (`load-test/view-1000.js`)

- k6을 사용한 동시 조회 테스트 (1,000 VU × 1회 = 1,000 요청)
- p95 < 2,000ms / 에러율 < 1% 임계값 설정
- bid 쿠키 없이 요청하여 모든 VU가 첫 조회로 처리되도록 설계

---

## ✅ 작업 체크리스트

- [x] `ViewFlushService` 구현 (5초 간격 배치 flush)
- [x] `ViewService.incrementViewCount()` 추가 (Redis 카운터 누적)
- [x] `ViewModule` 생성 및 모듈 의존성 정리
- [x] Story 조회수 처리 리팩토링 (fire-and-forget + 에러 핸들링)
- [x] Question 조회수 처리 리팩토링 (fire-and-forget + 에러 핸들링)
- [x] Project 조회수 처리 리팩토링 (fire-and-forget + 에러 핸들링)
- [x] `@nestjs/schedule` 패키지 추가 및 `AppModule` 등록
- [x] ESLint 규칙 완화 (PascalCase export function 허용)
- [x] k6 로드 테스트 스크립트 작성

---

## 📎 개발 일지 및 참고 자료

- [조회수 API의 DB 병목을 Redis로 해결하기](https://dongho-blog.kro.kr/posts/3415ca9b-265e-802e-9975-d8f7cb9e39d9)

### Redis Key 구조

- 중복 방지: `view:{resource}:{resourceId}:{viewerKey}`
- 누적 카운터: `view:count:{resource}:{id}`
- dirty set: `view:dirty:{resource}`

### 성능 측정

- 로컬 환경에서 k6을 사용한 동시 조회 테스트 (1,000 VU × 1회 = 1,000 요청)


지표 | Before (동기 처리) | After (Redis 배치) | 개선 효과
-- | -- | -- | --
평균 응답 시간 | 2.51초 | 0.88초 | 약 65% 감소
p95 응답 시간 | 3.80초 | 1.57초 | 약 58% 감소
처리량 (RPS) | 251 req/s | 581 req/s | 약 2.3배 증가
DB 쓰기 횟수 | 1,000건 | 0건 | 요청 처리 과정에서 DB 쓰기 제거
에러율 | 0% | 0% | -

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 조회수 집계 시스템 추가: Redis 기반 실시간 집계 및 주기적 DB 동기화
  * 부하 테스트 스크립트 추가: 1000 VU 시나리오 지원

* **문서**
  * Swagger/OpenAPI 문서화 표준 가이드 추가

* **개선사항**
  * 조회수 처리 비동기화(논블로킹) 및 오류 로깅 강화

* **의존성**
  * 스케줄링 라이브러리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Documentation**
  * API 엔드포인트 문서화 표준화 및 Swagger 명세 개선

* **New Features**
  * 조회수 추적 시스템 개선 및 자동 동기화 기능 추가

* **Chores**
  * 의존성 업데이트 및 코드 컨벤션 개선
  * 부하 테스트 스크립트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->